### PR TITLE
Wait for tag API visibility before gh release create --verify-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,20 @@ jobs:
               push origin "refs/tags/${RELEASE_TAG}"
           fi
 
+          # a successful git push does not guarantee the tag is visible to the
+          # REST API yet; --verify-tag reads through the API, so wait out the
+          # replication lag instead of failing the release on a stale read
+          for attempt in $(seq 1 30); do
+            if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" --silent 2>/dev/null; then
+              break
+            fi
+            if [ "${attempt}" = "30" ]; then
+              echo "::error::tag ${RELEASE_TAG} not visible via the API after 60s; re-run this Release run to resume publication" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+
           assets=(dist/SHA256SUMS)
           while IFS= read -r file; do
             assets+=("$file")


### PR DESCRIPTION
## Problem

The first live run of the tag-only release flow ([run 28916391639](https://github.com/datafusion-contrib/datafusion-go/actions/runs/28916391639)) pushed `v0.530100.1` successfully — branch protection stayed intact, the tag-only design worked — and then failed at the last command:

```
04:00:34.266  * [new tag]  v0.530100.1 -> v0.530100.1
04:00:34.607  tag v0.530100.1 doesn't exist in the repo datafusion-contrib/datafusion-go, aborting due to --verify-tag flag
```

`gh release create --verify-tag` reads the tag through the REST API 341ms after `git push` returned; the API read hit a replica that hadn't seen the tag yet. The same API endpoint returned the tag correctly moments later, and re-running the Release run resumed publication via the resume path.

## Fix

Poll `repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}` until the tag is API-visible (2s interval, bounded at 60s) between the tag push and `gh release create`. This keeps `--verify-tag` — the check is still valuable — while making the publish step immune to push-to-API replication lag. On timeout it fails with a pointer to the resume path, same recovery as today.

The loop also runs in resume mode, where the tag is long-since visible and the first probe succeeds immediately.