### PR TITLE
Add foreign table provider support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 
 generate:
 	go run ./internal/tools/genversions
-	cargo update --manifest-path rust/Cargo.toml -p datafusion-go -p datafusion -p datafusion-sql
+	cargo update --manifest-path rust/Cargo.toml -p datafusion-go -p datafusion -p datafusion-ffi -p datafusion-sql
 
 generate.check:
 	go run ./internal/tools/genversions -check

--- a/README.md
+++ b/README.md
@@ -399,9 +399,9 @@ rows, err := db.QueryContext(ctx, `SELECT ... FROM t WHERE ...`)
 A few contract points, all enforced or documented on `RegisterFFITableProvider`:
 
 - **Version handshake.** `providerVersion` must equal this package's `DataFusionVersion`; obtain it from the producing library, not from `DataFusionVersion`. The check runs before the provider pointer is dereferenced, so a mismatch is a clean error rather than a crash. The match is required to be exact — deliberately stricter than datafusion-ffi's major-version ABI contract, because datafusion is pre-1.0 and has broken layouts across minor releases.
-- **Ownership.** Registration clones the provider (bumping its refcount), so you retain ownership of the original pointer and may free it through its producing library once the call returns.
+- **Ownership.** The provider pointer must be memory owned by the producing foreign library (C/Rust), not Go heap memory, since native code retains callback pointers cloned out of it past the call. Registration clones the provider (bumping its refcount), so you retain ownership of the original pointer and may free it through its producing library once the call returns.
 - **Library lifetime.** The producing library must stay loaded for as long as the table is registered — the registered table calls back into its function pointers on every scan.
-- **Deregistration is explicit.** `RegisterFFITableProvider` returns a `*RegisteredTable` handle; call `Deregister` to remove the table before the producing library tears down. Closing the `*sql.Conn` also releases it. Dropping the handle does not.
+- **Deregistration is explicit.** `RegisterFFITableProvider` returns a `*RegisteredTable` handle; call `Deregister` to remove the table before the producing library tears down. The table's lifetime follows the session it was registered on: with an isolated session (`WithSharedSession(false)`) closing the `*sql.Conn` also releases it, but with a shared session (the default) it lives on the shared `SessionContext` and persists until `Deregister` or the owning `Connector` is closed. Dropping the handle never deregisters it.
 
 ### API Overview
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ From a source checkout, run `make bundle` once, then `go run ./examples/simple`.
 - **Standard `database/sql` driver** — registered as `datafusion`, with connection pooling, prepared statements, SQL parameters, and context cancellation.
 - **Files as tables** — `CREATE EXTERNAL TABLE` over CSV and Parquet files, `COPY ... TO` to write results back out.
 - **Arrow-native APIs** — stream results as `arrow.RecordBatch` values and register Go Arrow readers as DataFusion tables, with a zero-copy option.
+- **Foreign table providers** — register a `datafusion-ffi` `FFI_TableProvider` produced by another library and query it with projection/filter pushdown reaching the provider.
 - **Typed SQL parameters** — `?`, `$1`, and `$name` styles, plus typed wrappers for dates, times, timestamps, durations, decimals, and typed nulls.
 - **Context cancellation end to end** — Go contexts bridge to native cancellation during planning, stream creation, and record-batch reads.
 - **Structured errors** — machine-readable native error kinds, matchable with `errors.Is`.
@@ -379,6 +380,29 @@ if err := datafusion.RegisterArrowReader(ctx, conn, "events", rdr); err != nil {
 
 Do not use the zero-copy API with ordinary Go-allocated Arrow buffers unless you fully own that lifetime and cgo pointer-safety tradeoff.
 
+#### Register Foreign FFI Table Providers
+
+If another library produces a `datafusion-ffi` `FFI_TableProvider` — a language binding, or a client that talks to a remote catalog and streams Arrow — register it directly so SQL can plan against it, with projection and filter predicates pushed down into the provider:
+
+```go
+// providerPtr is an *FFI_TableProvider handed to you by the producing library,
+// and providerVersion is the datafusion version that library was built against.
+table, err := datafusion.RegisterFFITableProvider(ctx, conn, "t", providerPtr, providerVersion)
+if err != nil {
+	return err
+}
+defer table.Deregister(ctx)
+
+rows, err := db.QueryContext(ctx, `SELECT ... FROM t WHERE ...`)
+```
+
+A few contract points, all enforced or documented on `RegisterFFITableProvider`:
+
+- **Version handshake.** `providerVersion` must equal this package's `DataFusionVersion`; obtain it from the producing library, not from `DataFusionVersion`. The check runs before the provider pointer is dereferenced, so a mismatch is a clean error rather than a crash. The match is required to be exact — deliberately stricter than datafusion-ffi's major-version ABI contract, because datafusion is pre-1.0 and has broken layouts across minor releases.
+- **Ownership.** Registration clones the provider (bumping its refcount), so you retain ownership of the original pointer and may free it through its producing library once the call returns.
+- **Library lifetime.** The producing library must stay loaded for as long as the table is registered — the registered table calls back into its function pointers on every scan.
+- **Deregistration is explicit.** `RegisterFFITableProvider` returns a `*RegisteredTable` handle; call `Deregister` to remove the table before the producing library tears down. Closing the `*sql.Conn` also releases it. Dropping the handle does not.
+
 ### API Overview
 
 The most important exported APIs:
@@ -386,6 +410,7 @@ The most important exported APIs:
 - `NewConnector` / `NewConnectorWithInitContext`: pooled databases with setup SQL and connector options such as `WithSharedSession`.
 - `QueryArrowContext`: streams Arrow record batches from a `*sql.Conn`.
 - `RegisterArrowReader` / `RegisterArrowReaderZeroCopy`: register Go Arrow readers as DataFusion tables.
+- `RegisterFFITableProvider`: register a foreign `datafusion-ffi` `FFI_TableProvider` and query it with pushdown; returns a `*RegisteredTable` handle for explicit `Deregister`.
 - `ExecStatements`: executes an already-split slice of SQL statements.
 - `Error` and the `ErrNative*` sentinels: structured driver errors with operation type and native error kind.
 

--- a/connection.go
+++ b/connection.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"sync"
-	"unsafe"
 
 	"github.com/datafusion-contrib/datafusion-go/internal/native"
 )
@@ -20,19 +19,6 @@ type Conn struct {
 
 func newConn(conn *native.Connection, connector *Connector) *Conn {
 	return &Conn{conn: conn, connector: connector}
-}
-
-// RegisterFFITableProvider registers a foreign datafusion-ffi FFI_TableProvider
-// (produced by another library) as a queryable table under name. provider must
-// point to a valid FFI_TableProvider; it is cloned on registration, so the
-// caller retains ownership and should free the original.
-func (conn *Conn) RegisterFFITableProvider(name string, provider unsafe.Pointer) error {
-	conn.mu.Lock()
-	defer conn.mu.Unlock()
-	if conn.closed || conn.conn == nil {
-		return driver.ErrBadConn
-	}
-	return conn.conn.RegisterFFITableProvider(name, provider)
 }
 
 // Prepare validates and prepares query using a background context.

--- a/connection.go
+++ b/connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"sync"
+	"unsafe"
 
 	"github.com/datafusion-contrib/datafusion-go/internal/native"
 )
@@ -19,6 +20,19 @@ type Conn struct {
 
 func newConn(conn *native.Connection, connector *Connector) *Conn {
 	return &Conn{conn: conn, connector: connector}
+}
+
+// RegisterFFITableProvider registers a foreign datafusion-ffi FFI_TableProvider
+// (produced by another library) as a queryable table under name. provider must
+// point to a valid FFI_TableProvider; it is cloned on registration, so the
+// caller retains ownership and should free the original.
+func (conn *Conn) RegisterFFITableProvider(name string, provider unsafe.Pointer) error {
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	if conn.closed || conn.conn == nil {
+		return driver.ErrBadConn
+	}
+	return conn.conn.RegisterFFITableProvider(name, provider)
 }
 
 // Prepare validates and prepares query using a background context.

--- a/ffi_table_provider.go
+++ b/ffi_table_provider.go
@@ -1,0 +1,107 @@
+package datafusion
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"unsafe"
+)
+
+// RegisteredTable is a handle to a table registered on a connection by
+// RegisterFFITableProvider. Call Deregister to remove the table before the
+// producing library tears down; closing the underlying *sql.Conn also releases
+// it. The handle is safe for concurrent use.
+//
+// Dropping the handle does not deregister the table: the table's lifetime is
+// owned by the connection, not by this handle, and a caller may legitimately
+// keep querying the table after dropping the handle. Deregistration is
+// therefore always explicit.
+type RegisteredTable struct {
+	sqlConn *sql.Conn
+	name    string
+
+	mu   sync.Mutex
+	done bool
+}
+
+// RegisterFFITableProvider registers a foreign datafusion-ffi FFI_TableProvider,
+// produced by another library, as a queryable table named tableName on the
+// DataFusion connection backing sqlConn. Once registered, SQL executed on
+// sqlConn can scan the table, and projection/filter predicates are pushed down
+// into the foreign provider.
+//
+// provider must point to a valid, initialized datafusion-ffi FFI_TableProvider.
+// providerDataFusionVersion is the datafusion version the library that produced
+// provider was built against; obtain it from that library (not from
+// DataFusionVersion). Registration fails with an error if it does not equal this
+// package's DataFusionVersion — the two sides must link the same datafusion
+// version for the provider's memory layout to be compatible. This check happens
+// before provider is dereferenced, so a version mismatch is a clean error rather
+// than a crash; it is cooperative and cannot detect a mislabeled provider.
+//
+// Lifetime: registration clones the provider (bumping its internal refcount), so
+// the caller still owns the original FFI_TableProvider pointer and may free it
+// through its producing library once this call returns. The producing library
+// itself, however, must stay loaded for as long as the table remains registered
+// (until Deregister or until sqlConn is closed): the registered table calls back
+// into the provider's function pointers on every scan, and unloading the library
+// leaves them dangling. The DataFusion session backing the provider should also
+// outlive the registration; if it does not, queries against the table fail with
+// a clean error rather than crashing.
+func RegisterFFITableProvider(ctx context.Context, sqlConn *sql.Conn, tableName string, provider unsafe.Pointer, providerDataFusionVersion string) (*RegisteredTable, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if sqlConn == nil {
+		return nil, fmt.Errorf("datafusion sql connection is nil")
+	}
+	if tableName == "" {
+		return nil, fmt.Errorf("datafusion ffi table name is empty")
+	}
+	if provider == nil {
+		return nil, fmt.Errorf("datafusion ffi table provider is nil")
+	}
+	if providerDataFusionVersion == "" {
+		return nil, fmt.Errorf("datafusion ffi provider datafusion version is empty")
+	}
+
+	if err := withDataFusionConn(sqlConn, func(conn *Conn) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return conn.conn.RegisterFFITableProvider(tableName, provider, providerDataFusionVersion)
+	}); err != nil {
+		return nil, err
+	}
+
+	return &RegisteredTable{sqlConn: sqlConn, name: tableName}, nil
+}
+
+// Name returns the table name this handle refers to.
+func (t *RegisteredTable) Name() string {
+	return t.name
+}
+
+// Deregister removes the table from the connection's session. It is idempotent:
+// calling it more than once, or after the connection is closed, is a no-op that
+// returns nil. Deregister on a name that is no longer registered is not an error.
+func (t *RegisteredTable) Deregister(ctx context.Context) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.done {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	if err := withDataFusionConn(t.sqlConn, func(conn *Conn) error {
+		return conn.conn.DeregisterTable(t.name)
+	}); err != nil {
+		return err
+	}
+
+	t.done = true
+	return nil
+}

--- a/ffi_table_provider.go
+++ b/ffi_table_provider.go
@@ -31,6 +31,10 @@ type RegisteredTable struct {
 // sqlConn can scan the table, and projection/filter predicates are pushed down
 // into the foreign provider.
 //
+// The table is registered on sqlConn's session, following the usual session
+// semantics: with WithSharedSession it is registered on the shared session and
+// is therefore visible to every connection sharing it, not just sqlConn.
+//
 // provider must point to a valid, initialized datafusion-ffi FFI_TableProvider.
 // providerDataFusionVersion is the datafusion version the library that produced
 // provider was built against; obtain it from that library (not from
@@ -83,9 +87,11 @@ func (t *RegisteredTable) Name() string {
 	return t.name
 }
 
-// Deregister removes the table from the connection's session. Calling it more
-// than once is a no-op that returns nil, and deregistering a name that is no
-// longer registered is not an error.
+// Deregister removes the table from the session it was registered on. Under
+// WithSharedSession that is the shared session, so the table is removed for
+// every connection sharing it, not just sqlConn. Calling it more than once is a
+// no-op that returns nil, and deregistering a name that is no longer registered
+// is not an error.
 //
 // Closing the underlying *sql.Conn already releases the table, so an explicit
 // Deregister is only needed to remove it sooner. Like the other connection

--- a/ffi_table_provider.go
+++ b/ffi_table_provider.go
@@ -83,9 +83,14 @@ func (t *RegisteredTable) Name() string {
 	return t.name
 }
 
-// Deregister removes the table from the connection's session. It is idempotent:
-// calling it more than once, or after the connection is closed, is a no-op that
-// returns nil. Deregister on a name that is no longer registered is not an error.
+// Deregister removes the table from the connection's session. Calling it more
+// than once is a no-op that returns nil, and deregistering a name that is no
+// longer registered is not an error.
+//
+// Closing the underlying *sql.Conn already releases the table, so an explicit
+// Deregister is only needed to remove it sooner. Like the other connection
+// operations in this package, Deregister on a closed connection propagates the
+// error database/sql reports (sql.ErrConnDone) rather than masking it.
 func (t *RegisteredTable) Deregister(ctx context.Context) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/ffi_table_provider.go
+++ b/ffi_table_provider.go
@@ -10,13 +10,19 @@ import (
 
 // RegisteredTable is a handle to a table registered on a connection by
 // RegisterFFITableProvider. Call Deregister to remove the table before the
-// producing library tears down; closing the underlying *sql.Conn also releases
-// it. The handle is safe for concurrent use.
+// producing library tears down. The handle is safe for concurrent use.
 //
-// Dropping the handle does not deregister the table: the table's lifetime is
-// owned by the connection, not by this handle, and a caller may legitimately
-// keep querying the table after dropping the handle. Deregistration is
-// therefore always explicit.
+// The table's lifetime follows the session it was registered on, not this
+// handle. With an isolated session (WithSharedSession(false)) the table lives
+// only as long as sqlConn, so closing that *sql.Conn also releases it. With a
+// shared session (the default) it is registered on the connector's shared
+// SessionContext and outlives sqlConn: it persists until Deregister is called
+// or the owning Connector is closed, and closing sqlConn alone does not release
+// it.
+//
+// Dropping the handle never deregisters the table: a caller may legitimately
+// keep querying it after dropping the handle. Deregistration is therefore
+// always explicit.
 type RegisteredTable struct {
 	sqlConn *sql.Conn
 	name    string
@@ -35,7 +41,12 @@ type RegisteredTable struct {
 // semantics: with WithSharedSession it is registered on the shared session and
 // is therefore visible to every connection sharing it, not just sqlConn.
 //
-// provider must point to a valid, initialized datafusion-ffi FFI_TableProvider.
+// provider must point to a valid, initialized datafusion-ffi FFI_TableProvider
+// that is owned by the producing foreign library — memory allocated by that
+// library (C/Rust), not Go heap memory. Registration clones callback pointers
+// out of the provider and native code invokes them long after this call
+// returns, so passing a Go-allocated pointer would violate cgo's pointer-passing
+// rules and risk corruption once Go's garbage collector moves or frees it.
 // providerDataFusionVersion is the datafusion version the library that produced
 // provider was built against; obtain it from that library (not from
 // DataFusionVersion). Registration fails with an error if it does not equal this
@@ -48,9 +59,9 @@ type RegisteredTable struct {
 // the caller still owns the original FFI_TableProvider pointer and may free it
 // through its producing library once this call returns. The producing library
 // itself, however, must stay loaded for as long as the table remains registered
-// (until Deregister or until sqlConn is closed): the registered table calls back
-// into the provider's function pointers on every scan, and unloading the library
-// leaves them dangling. The DataFusion session backing the provider should also
+// (see RegisteredTable for exactly when that ends): the registered table calls
+// back into the provider's function pointers on every scan, and unloading the
+// library leaves them dangling. The DataFusion session backing the provider should also
 // outlive the registration; if it does not, queries against the table fail with
 // a clean error rather than crashing.
 func RegisterFFITableProvider(ctx context.Context, sqlConn *sql.Conn, tableName string, provider unsafe.Pointer, providerDataFusionVersion string) (*RegisteredTable, error) {
@@ -93,10 +104,14 @@ func (t *RegisteredTable) Name() string {
 // no-op that returns nil, and deregistering a name that is no longer registered
 // is not an error.
 //
-// Closing the underlying *sql.Conn already releases the table, so an explicit
-// Deregister is only needed to remove it sooner. Like the other connection
-// operations in this package, Deregister on a closed connection propagates the
-// error database/sql reports (sql.ErrConnDone) rather than masking it.
+// With an isolated session, closing the underlying *sql.Conn already releases
+// the table, so an explicit Deregister is only needed to remove it sooner. With
+// a shared session (the default) the table lives on the shared SessionContext,
+// so closing sqlConn does not release it: Deregister (or closing the owning
+// Connector) is required. Deregister runs on sqlConn, so it must still be open;
+// like the other connection operations in this package, Deregister on a closed
+// connection propagates the error database/sql reports (sql.ErrConnDone) rather
+// than masking it.
 func (t *RegisteredTable) Deregister(ctx context.Context) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/ffi_table_provider_test.go
+++ b/ffi_table_provider_test.go
@@ -1,0 +1,41 @@
+//go:build cgo
+
+package datafusion
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"unsafe"
+)
+
+// The positive round-trip (register a real FFI_TableProvider and query it) is
+// covered by the Rust test `registers_and_queries_ffi_table_provider`, which
+// can mint a provider in-process; a Go-level positive test would require a
+// second library to produce one. Here we verify the public binding routes
+// through to the native validation.
+func TestRegisterFFITableProviderRejectsNil(t *testing.T) {
+	db, err := sql.Open("datafusion", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeNoError(t, db)
+
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeNoError(t, conn)
+
+	var got error
+	if err := conn.Raw(func(dc any) error {
+		got = dc.(*Conn).RegisterFFITableProvider("t", unsafe.Pointer(nil))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || !strings.Contains(got.Error(), "nil") {
+		t.Fatalf("got %v, want an error mentioning a nil provider", got)
+	}
+}

--- a/ffi_table_provider_test.go
+++ b/ffi_table_provider_test.go
@@ -13,29 +13,68 @@ import (
 // The positive round-trip (register a real FFI_TableProvider and query it) is
 // covered by the Rust test `registers_and_queries_ffi_table_provider`, which
 // can mint a provider in-process; a Go-level positive test would require a
-// second library to produce one. Here we verify the public binding routes
-// through to the native validation.
-func TestRegisterFFITableProviderRejectsNil(t *testing.T) {
+// second library to produce one. Here we verify the public function validates
+// its arguments before dereferencing the provider pointer.
+func TestRegisterFFITableProviderRejectsNilProvider(t *testing.T) {
+	conn := openTestConn(t)
+
+	_, err := RegisterFFITableProvider(context.Background(), conn, "t", unsafe.Pointer(nil), DataFusionVersion)
+	if err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("got %v, want an error mentioning a nil provider", err)
+	}
+}
+
+func TestRegisterFFITableProviderRejectsEmptyName(t *testing.T) {
+	conn := openTestConn(t)
+
+	_, err := RegisterFFITableProvider(context.Background(), conn, "", validProviderPtr(), DataFusionVersion)
+	if err == nil || !strings.Contains(err.Error(), "name") {
+		t.Fatalf("got %v, want an error mentioning an empty table name", err)
+	}
+}
+
+func TestRegisterFFITableProviderRejectsEmptyVersion(t *testing.T) {
+	conn := openTestConn(t)
+
+	_, err := RegisterFFITableProvider(context.Background(), conn, "t", validProviderPtr(), "")
+	if err == nil || !strings.Contains(err.Error(), "version") {
+		t.Fatalf("got %v, want an error mentioning an empty version", err)
+	}
+}
+
+// A version mismatch must be rejected *before* the provider is dereferenced.
+// We pass a bogus (but readable) pointer that is not a real FFI_TableProvider:
+// if the version check did not gate the dereference, the native side would read
+// garbage as a vtable and crash. Reaching a clean error proves the ordering.
+func TestRegisterFFITableProviderRejectsVersionMismatch(t *testing.T) {
+	conn := openTestConn(t)
+
+	_, err := RegisterFFITableProvider(context.Background(), conn, "t", validProviderPtr(), "0.0.0-not-a-real-version")
+	if err == nil || !strings.Contains(err.Error(), "0.0.0-not-a-real-version") {
+		t.Fatalf("got %v, want a datafusion version-mismatch error", err)
+	}
+}
+
+// validProviderPtr returns a non-nil pointer to readable memory that is never
+// dereferenced by tests exercising the pre-dereference validation paths.
+func validProviderPtr() unsafe.Pointer {
+	return unsafe.Pointer(new([64]byte))
+}
+
+func openTestConn(t *testing.T) *sql.Conn {
+	t.Helper()
+
 	db, err := sql.Open("datafusion", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closeNoError(t, db)
+	t.Cleanup(func() { closeNoError(t, db) })
 
 	conn, err := db.Conn(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer closeNoError(t, conn)
+	t.Cleanup(func() { closeNoError(t, conn) })
 
-	var got error
-	if err := conn.Raw(func(dc any) error {
-		got = dc.(*Conn).RegisterFFITableProvider("t", unsafe.Pointer(nil))
-		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if got == nil || !strings.Contains(got.Error(), "nil") {
-		t.Fatalf("got %v, want an error mentioning a nil provider", got)
-	}
+	return conn
 }

--- a/internal/native/dynamic_loader.h
+++ b/internal/native/dynamic_loader.h
@@ -25,6 +25,8 @@ typedef int (*dfgo_connection_open_shared_fn)(dfgo_database *, dfgo_connection *
 typedef void (*dfgo_connection_close_fn)(dfgo_connection *);
 typedef int (*dfgo_connection_register_arrow_ipc_fn)(dfgo_connection *, const char *, const uint8_t *, int64_t, dfgo_error **);
 typedef int (*dfgo_connection_register_arrow_stream_fn)(dfgo_connection *, const char *, struct ArrowArrayStream *, dfgo_error **);
+typedef int (*dfgo_connection_register_ffi_table_provider_fn)(dfgo_connection *, const char *, const void *, const char *, dfgo_error **);
+typedef int (*dfgo_connection_deregister_table_fn)(dfgo_connection *, const char *, dfgo_error **);
 typedef int (*dfgo_prepare_fn)(dfgo_connection *, const char *, dfgo_statement **, dfgo_error **);
 typedef void (*dfgo_statement_close_fn)(dfgo_statement *);
 typedef int64_t (*dfgo_statement_num_params_fn)(dfgo_statement *);
@@ -49,6 +51,8 @@ static dfgo_connection_open_shared_fn p_dfgo_connection_open_shared;
 static dfgo_connection_close_fn p_dfgo_connection_close;
 static dfgo_connection_register_arrow_ipc_fn p_dfgo_connection_register_arrow_ipc;
 static dfgo_connection_register_arrow_stream_fn p_dfgo_connection_register_arrow_stream;
+static dfgo_connection_register_ffi_table_provider_fn p_dfgo_connection_register_ffi_table_provider;
+static dfgo_connection_deregister_table_fn p_dfgo_connection_deregister_table;
 static dfgo_prepare_fn p_dfgo_prepare;
 static dfgo_statement_close_fn p_dfgo_statement_close;
 static dfgo_statement_num_params_fn p_dfgo_statement_num_params;
@@ -139,6 +143,8 @@ static int dfgo_native_load_library(const char *path) {
 	DFGO_LOAD_SYMBOL(dfgo_connection_close);
 	DFGO_LOAD_SYMBOL(dfgo_connection_register_arrow_ipc);
 	DFGO_LOAD_SYMBOL(dfgo_connection_register_arrow_stream);
+	DFGO_LOAD_SYMBOL(dfgo_connection_register_ffi_table_provider);
+	DFGO_LOAD_SYMBOL(dfgo_connection_deregister_table);
 	DFGO_LOAD_SYMBOL(dfgo_prepare);
 	DFGO_LOAD_SYMBOL(dfgo_statement_close);
 	DFGO_LOAD_SYMBOL(dfgo_statement_num_params);
@@ -190,6 +196,14 @@ static int dfgo_connection_register_arrow_ipc(dfgo_connection *conn, const char 
 
 static int dfgo_connection_register_arrow_stream(dfgo_connection *conn, const char *name, struct ArrowArrayStream *stream, dfgo_error **err) {
 	return p_dfgo_connection_register_arrow_stream(conn, name, stream, err);
+}
+
+static int dfgo_connection_register_ffi_table_provider(dfgo_connection *conn, const char *name, const void *provider, const char *provider_datafusion_version, dfgo_error **err) {
+	return p_dfgo_connection_register_ffi_table_provider(conn, name, provider, provider_datafusion_version, err);
+}
+
+static int dfgo_connection_deregister_table(dfgo_connection *conn, const char *name, dfgo_error **err) {
+	return p_dfgo_connection_deregister_table(conn, name, err);
 }
 
 static int dfgo_prepare(dfgo_connection *conn, const char *query, dfgo_statement **out, dfgo_error **err) {

--- a/internal/native/native.go
+++ b/internal/native/native.go
@@ -268,6 +268,27 @@ func (conn *Connection) RegisterArrowIPC(name string, data []byte) error {
 	return nil
 }
 
+// RegisterFFITableProvider registers a foreign datafusion-ffi FFI_TableProvider
+// (produced by another library) under name. provider must point to a valid
+// FFI_TableProvider; the callee clones it, so the caller retains ownership.
+func (conn *Connection) RegisterFFITableProvider(name string, provider unsafe.Pointer) error {
+	if conn == nil || conn.ptr == nil {
+		return errors.New("datafusion-go connection is closed")
+	}
+	if provider == nil {
+		return errors.New("datafusion-go FFI table provider is nil")
+	}
+
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	var cerr *C.dfgo_error
+	if C.dfgo_connection_register_ffi_table_provider(conn.ptr, cname, provider, &cerr) != stateOK {
+		return takeError(cerr)
+	}
+	return nil
+}
+
 func (conn *Connection) RegisterArrowReaderZeroCopy(name string, reader array.RecordReader) error {
 	if conn == nil || conn.ptr == nil {
 		return errors.New("datafusion-go connection is closed")

--- a/internal/native/native.go
+++ b/internal/native/native.go
@@ -270,8 +270,13 @@ func (conn *Connection) RegisterArrowIPC(name string, data []byte) error {
 
 // RegisterFFITableProvider registers a foreign datafusion-ffi FFI_TableProvider
 // (produced by another library) under name. provider must point to a valid
-// FFI_TableProvider; the callee clones it, so the caller retains ownership.
-func (conn *Connection) RegisterFFITableProvider(name string, provider unsafe.Pointer) error {
+// FFI_TableProvider; the callee clones it, so the caller retains ownership of
+// the pointer. providerDataFusionVersion is the datafusion version the producing
+// library reports, checked against the native library's version before the
+// provider is dereferenced. The producing library must stay loaded for as long
+// as the table is registered, since the registered table calls back into it on
+// every scan. See datafusion.RegisterFFITableProvider for the full contract.
+func (conn *Connection) RegisterFFITableProvider(name string, provider unsafe.Pointer, providerDataFusionVersion string) error {
 	if conn == nil || conn.ptr == nil {
 		return errors.New("datafusion-go connection is closed")
 	}
@@ -281,9 +286,28 @@ func (conn *Connection) RegisterFFITableProvider(name string, provider unsafe.Po
 
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
+	cversion := C.CString(providerDataFusionVersion)
+	defer C.free(unsafe.Pointer(cversion))
 
 	var cerr *C.dfgo_error
-	if C.dfgo_connection_register_ffi_table_provider(conn.ptr, cname, provider, &cerr) != stateOK {
+	if C.dfgo_connection_register_ffi_table_provider(conn.ptr, cname, provider, cversion, &cerr) != stateOK {
+		return takeError(cerr)
+	}
+	return nil
+}
+
+// DeregisterTable removes a table previously registered on the connection's
+// session. Removing a name that is not registered is not an error.
+func (conn *Connection) DeregisterTable(name string) error {
+	if conn == nil || conn.ptr == nil {
+		return errors.New("datafusion-go connection is closed")
+	}
+
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	var cerr *C.dfgo_error
+	if C.dfgo_connection_deregister_table(conn.ptr, cname, &cerr) != stateOK {
 		return takeError(cerr)
 	}
 	return nil

--- a/internal/native/native_nocgo.go
+++ b/internal/native/native_nocgo.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
+	"unsafe"
 
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/arrio"
@@ -34,6 +35,10 @@ func (conn *Connection) RegisterArrowIPC(string, []byte) error {
 }
 
 func (conn *Connection) RegisterArrowReaderZeroCopy(string, array.RecordReader) error {
+	return errCgoDisabled
+}
+
+func (conn *Connection) RegisterFFITableProvider(string, unsafe.Pointer) error {
 	return errCgoDisabled
 }
 

--- a/internal/native/native_nocgo.go
+++ b/internal/native/native_nocgo.go
@@ -38,7 +38,11 @@ func (conn *Connection) RegisterArrowReaderZeroCopy(string, array.RecordReader) 
 	return errCgoDisabled
 }
 
-func (conn *Connection) RegisterFFITableProvider(string, unsafe.Pointer) error {
+func (conn *Connection) RegisterFFITableProvider(string, unsafe.Pointer, string) error {
+	return errCgoDisabled
+}
+
+func (conn *Connection) DeregisterTable(string) error {
 	return errCgoDisabled
 }
 

--- a/internal/tools/genversions/main.go
+++ b/internal/tools/genversions/main.go
@@ -243,6 +243,7 @@ func updateCargoToml(path string, cfg config) ([]byte, error) {
 	section := ""
 	packageVersionSet := false
 	datafusionSet := false
+	datafusionFFISet := false
 	datafusionSQLSet := false
 	for _, raw := range strings.SplitAfter(string(data), "\n") {
 		line := strings.TrimSpace(raw)
@@ -257,6 +258,9 @@ func updateCargoToml(path string, cfg config) ([]byte, error) {
 		case section == "dependencies" && strings.HasPrefix(line, "datafusion = "):
 			fmt.Fprintf(&out, "datafusion = %q\n", "="+cfg.DataFusionVersion)
 			datafusionSet = true
+		case section == "dependencies" && strings.HasPrefix(line, "datafusion-ffi = "):
+			fmt.Fprintf(&out, "datafusion-ffi = %q\n", "="+cfg.DataFusionVersion)
+			datafusionFFISet = true
 		case section == "dependencies" && strings.HasPrefix(line, "datafusion-sql = "):
 			fmt.Fprintf(&out, "datafusion-sql = %q\n", "="+cfg.DataFusionVersion)
 			datafusionSQLSet = true
@@ -271,6 +275,9 @@ func updateCargoToml(path string, cfg config) ([]byte, error) {
 	}
 	if !datafusionSet {
 		missing = append(missing, "[dependencies].datafusion")
+	}
+	if !datafusionFFISet {
+		missing = append(missing, "[dependencies].datafusion-ffi")
 	}
 	if !datafusionSQLSet {
 		missing = append(missing, "[dependencies].datafusion-sql")

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,54 @@
 version = 4
 
 [[package]]
+name = "abi_stable"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d6512d3eb05ffe5004c59c206de7f99c34951504056ce23fc953842f12c445"
+dependencies = [
+ "abi_stable_derive",
+ "abi_stable_shared",
+ "const_panic",
+ "core_extensions",
+ "crossbeam-channel",
+ "generational-arena",
+ "libloading",
+ "lock_api",
+ "parking_lot",
+ "paste",
+ "repr_offset",
+ "rustc_version",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "abi_stable_derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7178468b407a4ee10e881bc7a328a65e739f0863615cca4429d43916b05e898"
+dependencies = [
+ "abi_stable_shared",
+ "as_derive_utils",
+ "core_extensions",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+ "typed-arena",
+]
+
+[[package]]
+name = "abi_stable_shared"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b5df7688c123e63f4d4d649cba63f2967ba7f7861b1664fca3f77d3dad2b63"
+dependencies = [
+ "core_extensions",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +362,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "as_derive_utils"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff3c96645900a44cf11941c111bd08a6573b0e2f9f69bc9264b179d8fae753c4"
+dependencies = [
+ "core_extensions",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +386,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-ffi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4de21c0feef7e5a556e51af767c953f0501f7f300ba785cc99c47bdc8081a50"
+dependencies = [
+ "abi_stable",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,7 +402,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -547,6 +616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +635,21 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core_extensions"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bb5e5d0269fd4f739ea6cedaf29c16d81c27a7ce7582008e90eb50dcd57003"
+dependencies = [
+ "core_extensions_proc_macros",
+]
+
+[[package]]
+name = "core_extensions_proc_macros"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533d38ecd2709b7608fb8e18e4504deb99e9a72879e6aa66373a76d8dc4259ea"
 
 [[package]]
 name = "cpufeatures"
@@ -583,6 +676,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -983,6 +1085,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-ffi"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95173344d04ba62755c949bf44f8d1a6e4414cf6392a635db96c07e711b9a3c"
+dependencies = [
+ "abi_stable",
+ "arrow",
+ "arrow-schema",
+ "async-ffi",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-proto",
+ "datafusion-proto-common",
+ "datafusion-session",
+ "futures",
+ "log",
+ "prost",
+ "semver",
+ "tokio",
+]
+
+[[package]]
 name = "datafusion-functions"
 version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1256,7 @@ version = "0.530100.1"
 dependencies = [
  "arrow",
  "datafusion",
+ "datafusion-ffi",
  "datafusion-sql",
  "futures",
  "tokio",
@@ -1138,7 +1271,7 @@ checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
 dependencies = [
  "datafusion-doc",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1269,6 +1402,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-proto"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a387aaef949dc16bb6abc81bd1af850ec7449183aef011214f9724957495738"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-catalog",
+ "datafusion-catalog-listing",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-datasource-arrow",
+ "datafusion-datasource-csv",
+ "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-table",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-proto-common",
+ "object_store",
+ "prost",
+ "rand",
+]
+
+[[package]]
+name = "datafusion-proto-common"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e614c7c53a9c304c6a850b821010bb492e57300311835f1180613f9d2c63d9"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "prost",
+]
+
+[[package]]
 name = "datafusion-pruning"
 version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,7 +1509,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1478,7 +1650,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1508,6 +1680,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generational-arena"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1898,6 +2079,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
 name = "liblzma"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,7 +2402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2221,6 +2412,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2300,7 +2514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2340,6 +2554,15 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "repr_offset"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1070755bd29dffc19d0971cab794e607839ba2ef4b69a9e6fbc8733c1b72ea"
+dependencies = [
+ "tstr",
+]
 
 [[package]]
 name = "rustc_version"
@@ -2409,6 +2632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2428,7 +2652,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2516,7 +2740,7 @@ checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2546,6 +2770,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -2563,7 +2798,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2596,7 +2831,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2648,7 +2883,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2695,7 +2930,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2708,16 +2943,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tstr"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8e0294f14baae476d0dd0a2d780b2e24d66e349a9de876f5126777a37bdba7"
+dependencies = [
+ "tstr_proc_macros",
+]
+
+[[package]]
+name = "tstr_proc_macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78122066b0cb818b8afd08f7ed22f7fdbc3e90815035726f0840d0d26c0747a"
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
 
 [[package]]
 name = "unicode-ident"
@@ -2854,7 +3116,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2912,6 +3174,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2919,6 +3197,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2941,7 +3225,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2952,7 +3236,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3024,7 +3308,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3040,7 +3324,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3107,7 +3391,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3128,7 +3412,7 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3148,7 +3432,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3182,7 +3466,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 [dependencies]
 arrow = { version = "58", features = ["ffi"] }
 datafusion = "=53.1.0"
+datafusion-ffi = "=53.1.0"
 datafusion-sql = "=53.1.0"
 futures = "0.3"
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread", "sync"] }

--- a/rust/include/datafusion_go.h
+++ b/rust/include/datafusion_go.h
@@ -76,7 +76,12 @@ typedef struct dfgo_parameter {
  *   even when later validation or registration fails.
  * - dfgo_connection_register_ffi_table_provider borrows the FFI_TableProvider
  *   and clones it into the session; the caller retains ownership of the
- *   pointer and must free it through its producing library.
+ *   pointer and must free it through its producing library. The clone only
+ *   bumps a refcount: the producing library must stay loaded and un-freed for
+ *   as long as the table is registered, since the registered table calls back
+ *   into the provider on every scan. provider_datafusion_version is checked
+ *   against this library's datafusion version before the provider is
+ *   dereferenced; a mismatch is reported as an error rather than risking UB.
  * - dfgo_statement_execute_with_params borrows params and all nested pointers
  *   only for the duration of the call. Parameters are per-call state, so
  *   concurrent executions with separate params arrays cannot interleave
@@ -95,7 +100,8 @@ int dfgo_connection_open_shared(dfgo_database *db, dfgo_connection **out, dfgo_e
 void dfgo_connection_close(dfgo_connection *conn);
 int dfgo_connection_register_arrow_ipc(dfgo_connection *conn, const char *name, const uint8_t *data, int64_t len, dfgo_error **err);
 int dfgo_connection_register_arrow_stream(dfgo_connection *conn, const char *name, struct ArrowArrayStream *stream, dfgo_error **err);
-int dfgo_connection_register_ffi_table_provider(dfgo_connection *conn, const char *name, const void *provider, dfgo_error **err);
+int dfgo_connection_register_ffi_table_provider(dfgo_connection *conn, const char *name, const void *provider, const char *provider_datafusion_version, dfgo_error **err);
+int dfgo_connection_deregister_table(dfgo_connection *conn, const char *name, dfgo_error **err);
 
 int dfgo_prepare(dfgo_connection *conn, const char *query, dfgo_statement **out, dfgo_error **err);
 void dfgo_statement_close(dfgo_statement *stmt);

--- a/rust/include/datafusion_go.h
+++ b/rust/include/datafusion_go.h
@@ -74,6 +74,9 @@ typedef struct dfgo_parameter {
  *   remain live for the duration of the call.
  * - dfgo_connection_register_arrow_stream consumes a non-null ArrowArrayStream
  *   even when later validation or registration fails.
+ * - dfgo_connection_register_ffi_table_provider borrows the FFI_TableProvider
+ *   and clones it into the session; the caller retains ownership of the
+ *   pointer and must free it through its producing library.
  * - dfgo_statement_execute_with_params borrows params and all nested pointers
  *   only for the duration of the call. Parameters are per-call state, so
  *   concurrent executions with separate params arrays cannot interleave
@@ -92,6 +95,7 @@ int dfgo_connection_open_shared(dfgo_database *db, dfgo_connection **out, dfgo_e
 void dfgo_connection_close(dfgo_connection *conn);
 int dfgo_connection_register_arrow_ipc(dfgo_connection *conn, const char *name, const uint8_t *data, int64_t len, dfgo_error **err);
 int dfgo_connection_register_arrow_stream(dfgo_connection *conn, const char *name, struct ArrowArrayStream *stream, dfgo_error **err);
+int dfgo_connection_register_ffi_table_provider(dfgo_connection *conn, const char *name, const void *provider, dfgo_error **err);
 
 int dfgo_prepare(dfgo_connection *conn, const char *query, dfgo_statement **out, dfgo_error **err);
 void dfgo_statement_close(dfgo_statement *stmt);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -283,6 +283,21 @@ impl fmt::Display for CancelledError {
 
 impl std::error::Error for CancelledError {}
 
+// Raised when polling the DataFusion stream panics — most plausibly inside a
+// foreign FFI table provider's execution. The panic is contained before it can
+// unwind across the Arrow C stream callback into Go, and reported as a terminal
+// stream error instead.
+#[derive(Debug)]
+struct ReaderPanicError;
+
+impl fmt::Display for ReaderPanicError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("panic while reading query results across datafusion-go native boundary")
+    }
+}
+
+impl std::error::Error for ReaderPanicError {}
+
 struct StreamingReader {
     // Hold Inner so the runtime and SessionContext stay alive for every C stream
     // callback. The Go side may close statements/connections while rows remain.
@@ -309,15 +324,32 @@ impl Iterator for StreamingReader {
 
         let cancel = self.cancel.clone();
         let stream = &mut self.stream;
+        let runtime = &self.inner.runtime;
         // Arrow's C stream API is pull-based and synchronous. DataFusion's
         // stream is async, so each pull blocks this crate's runtime until either
         // the next batch arrives or cancellation wins the select.
-        let next = self.inner.runtime.block_on(async {
-            tokio::select! {
-                _ = cancel.cancelled() => Some(Err(cancelled_datafusion_error())),
-                item = stream.next() => item,
+        //
+        // Polling runs the table provider's execution, which for a foreign FFI
+        // provider is arbitrary producer code. A panic there must not unwind
+        // across the Arrow C stream callback into Go (undefined behavior), so it
+        // is contained here and reported as a terminal error, mirroring the
+        // `run_ffi` guard on the synchronous entry points.
+        let polled = catch_unwind(AssertUnwindSafe(|| {
+            runtime.block_on(async {
+                tokio::select! {
+                    _ = cancel.cancelled() => Some(Err(cancelled_datafusion_error())),
+                    item = stream.next() => item,
+                }
+            })
+        }));
+
+        let next = match polled {
+            Ok(next) => next,
+            Err(_) => {
+                self.done = true;
+                return Some(Err(ArrowError::ExternalError(Box::new(ReaderPanicError))));
             }
-        });
+        };
 
         match next {
             Some(Ok(batch)) => Some(Ok(batch)),
@@ -1980,6 +2012,52 @@ mod tests {
         assert_eq!(rc, DFG_ERR);
         assert!(!err.is_null());
         unsafe { dfgo_error_free(err) };
+    }
+
+    /// A panic while polling the result stream — the path a foreign FFI table
+    /// provider's execution runs on — is contained and surfaced as a terminal
+    /// error, rather than unwinding across the Arrow C stream callback into Go.
+    #[test]
+    fn panic_while_polling_stream_is_contained() {
+        use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+        use futures::stream;
+
+        fn panicking_batch() -> Result<RecordBatch, DataFusionError> {
+            panic!("boom from a foreign table provider scan");
+        }
+
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "a",
+            DataType::Int64,
+            false,
+        )]));
+        // The panic fires when the stream is first polled, inside next().
+        let panicking = stream::once(async { panicking_batch() });
+        let stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&schema),
+            panicking,
+        ));
+
+        let mut reader = StreamingReader {
+            inner: Arc::new(Inner {
+                runtime: Arc::new(Runtime::new().expect("runtime")),
+                ctx: SessionContext::new(),
+            }),
+            schema,
+            stream,
+            cancel: Arc::new(CancelToken::new()),
+            done: false,
+        };
+
+        match reader.next() {
+            Some(Err(ArrowError::ExternalError(err))) => {
+                assert!(err.downcast_ref::<ReaderPanicError>().is_some());
+            }
+            other => panic!("expected a contained panic error, got {other:?}"),
+        }
+        // The reader is terminal after a contained panic and never re-polls.
+        assert!(reader.next().is_none());
     }
 
     #[test]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1435,6 +1435,9 @@ pub unsafe extern "C" fn dfgo_connection_register_ffi_table_provider(
             return Err(FfiError::invalid_argument("provider handle is null"));
         }
         let name = cstr_to_string(name, "table name")?;
+        if name.trim().is_empty() {
+            return Err(FfiError::invalid_argument("table name is empty"));
+        }
         let provider_version =
             cstr_to_string(provider_datafusion_version, "provider datafusion version")?;
 
@@ -1443,6 +1446,12 @@ pub unsafe extern "C" fn dfgo_connection_register_ffi_table_provider(
         // anything out of it — including its own `version` fn-pointer — is only
         // sound once we know the layouts match. A mismatch becomes a clean error
         // instead of undefined behavior.
+        //
+        // This requires an exact datafusion version match, which is deliberately
+        // stricter than datafusion-ffi's own contract (it promises ABI stability
+        // at the major version only; see `datafusion_ffi::version`). datafusion
+        // is pre-1.0 and has broken layouts across minor/patch releases, so we
+        // refuse anything but an exact match rather than trust a looser bound.
         let expected = datafusion_version_str();
         if provider_version != expected {
             return Err(FfiError::invalid_argument(format!(
@@ -1911,8 +1920,7 @@ mod tests {
 
         // Deregistering removes the table, so planning against it now fails.
         let mut derr: *mut dfgo_error = ptr::null_mut();
-        let drc =
-            unsafe { dfgo_connection_deregister_table(&mut conn, name.as_ptr(), &mut derr) };
+        let drc = unsafe { dfgo_connection_deregister_table(&mut conn, name.as_ptr(), &mut derr) };
         assert_eq!(drc, DFG_OK, "deregister returned an error");
         assert!(derr.is_null(), "deregister set an error");
         let after = runtime.block_on(async { conn.inner.ctx.sql("SELECT a FROM t").await });

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1169,6 +1169,15 @@ pub extern "C" fn dfgo_datafusion_version() -> *const c_char {
     DATAFUSION_VERSION.as_ptr().cast()
 }
 
+/// The datafusion version this crate links, as a `&str`, for the FFI provider
+/// version handshake. Derived from the generated `DATAFUSION_VERSION` bytes.
+fn datafusion_version_str() -> &'static str {
+    CStr::from_bytes_with_nul(DATAFUSION_VERSION)
+        .expect("generated DATAFUSION_VERSION is NUL-terminated")
+        .to_str()
+        .expect("generated DATAFUSION_VERSION is valid UTF-8")
+}
+
 /// # Safety
 ///
 /// `dsn`, when non-null, must point to a valid NUL-terminated C string for the
@@ -1386,17 +1395,36 @@ pub unsafe extern "C" fn dfgo_connection_register_arrow_stream(
 /// provider is imported via datafusion-ffi's `From<&FFI_TableProvider>`, which
 /// clones it — the caller retains ownership of `provider` and must free it.
 ///
+/// The clone only bumps the foreign provider's refcount; the registered table
+/// invokes the provider's function pointers on every scan. The producing
+/// library therefore must stay loaded and un-freed for as long as the table
+/// remains registered on `conn` — its `scan`/`clone`/`release` function
+/// pointers dangle if it is unloaded, which is undefined behavior. The session
+/// backing the provider's (weakly held) task context should also outlive the
+/// registration; if it does not, queries against the table fail with a clean
+/// "TaskContextProvider went out of scope" error rather than crashing.
+///
+/// `provider_datafusion_version` is the datafusion version the producing
+/// library reports building against. It is compared against this crate's
+/// version *before* `provider` is dereferenced: `FFI_TableProvider` is a plain
+/// `repr(C)` vtable with no stable prefix, so its layout (and its own `version`
+/// function pointer) can only be trusted once the versions are known to match.
+/// A mismatch is rejected as an error instead of risking undefined behavior.
+/// This is a cooperative check and cannot detect a mislabeled provider.
+///
 /// # Safety
 ///
-/// `conn` must be a live connection handle. `name` must be a valid
-/// NUL-terminated C string. `provider` must be a non-null pointer to a valid
-/// `FFI_TableProvider`. `err`, when non-null, must point to writable
-/// error-handle storage.
+/// `conn` must be a live connection handle. `name` and
+/// `provider_datafusion_version` must be valid NUL-terminated C strings.
+/// `provider` must be a non-null pointer to a valid `FFI_TableProvider` built
+/// against the reported datafusion version. `err`, when non-null, must point to
+/// writable error-handle storage.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn dfgo_connection_register_ffi_table_provider(
     conn: *mut dfgo_connection,
     name: *const c_char,
     provider: *const c_void,
+    provider_datafusion_version: *const c_char,
     err: *mut *mut dfgo_error,
 ) -> i32 {
     run_ffi(err, || {
@@ -1407,14 +1435,60 @@ pub unsafe extern "C" fn dfgo_connection_register_ffi_table_provider(
             return Err(FfiError::invalid_argument("provider handle is null"));
         }
         let name = cstr_to_string(name, "table name")?;
+        let provider_version =
+            cstr_to_string(provider_datafusion_version, "provider datafusion version")?;
+
+        // Out-of-band version handshake, checked BEFORE the provider is
+        // dereferenced. Because `FFI_TableProvider` has no stable prefix, reading
+        // anything out of it — including its own `version` fn-pointer — is only
+        // sound once we know the layouts match. A mismatch becomes a clean error
+        // instead of undefined behavior.
+        let expected = datafusion_version_str();
+        if provider_version != expected {
+            return Err(FfiError::invalid_argument(format!(
+                "incompatible FFI table provider: datafusion-go links datafusion \
+                 {expected}, but the provider reports {provider_version}; both sides \
+                 must link the same datafusion version"
+            )));
+        }
+
         // SAFETY: `conn` is non-null and borrowed only for the duration of
         // registration.
         let conn = unsafe { &*conn };
-        // SAFETY: `provider` is non-null and, per the contract, points to a
-        // valid `FFI_TableProvider`. We only borrow it; `From` clones it.
+        // SAFETY: `provider` is non-null, the version handshake above confirmed a
+        // matching datafusion build, and per the contract it points to a valid
+        // `FFI_TableProvider`. We only borrow it; `From` clones it.
         let ffi_provider = unsafe { &*(provider as *const FFI_TableProvider) };
         let table: Arc<dyn TableProvider> = ffi_provider.into();
         conn.inner.ctx.register_table(&name, table)?;
+        Ok(())
+    })
+}
+
+/// Deregister a table previously registered on `conn` (for example one added by
+/// [`dfgo_connection_register_ffi_table_provider`]). Deregistering a name that
+/// is not currently registered is not an error.
+///
+/// # Safety
+///
+/// `conn` must be a live connection handle. `name` must be a valid
+/// NUL-terminated C string. `err`, when non-null, must point to writable
+/// error-handle storage.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dfgo_connection_deregister_table(
+    conn: *mut dfgo_connection,
+    name: *const c_char,
+    err: *mut *mut dfgo_error,
+) -> i32 {
+    run_ffi(err, || {
+        if conn.is_null() {
+            return Err(FfiError::invalid_argument("connection handle is null"));
+        }
+        let name = cstr_to_string(name, "table name")?;
+        // SAFETY: `conn` is non-null and borrowed only for the duration of the
+        // deregistration.
+        let conn = unsafe { &*conn };
+        conn.inner.ctx.deregister_table(&name)?;
         Ok(())
     })
 }
@@ -1805,12 +1879,14 @@ mod tests {
 
         // Exercise the exported C entry point exactly as Go calls it.
         let name = CString::new("t").unwrap();
+        let version = CString::new(datafusion_version_str()).unwrap();
         let mut err: *mut dfgo_error = ptr::null_mut();
         let rc = unsafe {
             dfgo_connection_register_ffi_table_provider(
                 &mut conn,
                 name.as_ptr(),
                 &ffi as *const FFI_TableProvider as *const std::ffi::c_void,
+                version.as_ptr(),
                 &mut err,
             )
         };
@@ -1832,6 +1908,44 @@ mod tests {
             .map(|b| b.num_rows())
             .sum();
         assert_eq!(rows, 2, "expected rows a=2,3");
+
+        // Deregistering removes the table, so planning against it now fails.
+        let mut derr: *mut dfgo_error = ptr::null_mut();
+        let drc =
+            unsafe { dfgo_connection_deregister_table(&mut conn, name.as_ptr(), &mut derr) };
+        assert_eq!(drc, DFG_OK, "deregister returned an error");
+        assert!(derr.is_null(), "deregister set an error");
+        let after = runtime.block_on(async { conn.inner.ctx.sql("SELECT a FROM t").await });
+        assert!(after.is_err(), "table should be gone after deregister");
+    }
+
+    /// A datafusion version mismatch is rejected before the provider pointer is
+    /// dereferenced, so a bogus pointer never gets read as a vtable.
+    #[test]
+    fn rejects_version_mismatch_before_dereference() {
+        let mut conn = dfgo_connection {
+            inner: Arc::new(Inner {
+                runtime: Arc::new(Runtime::new().expect("runtime")),
+                ctx: SessionContext::new(),
+            }),
+        };
+        let name = CString::new("t").unwrap();
+        let version = CString::new("0.0.0-not-a-real-version").unwrap();
+        // Not a real FFI_TableProvider; must never be dereferenced.
+        let bogus: [u8; 64] = [0; 64];
+        let mut err: *mut dfgo_error = ptr::null_mut();
+        let rc = unsafe {
+            dfgo_connection_register_ffi_table_provider(
+                &mut conn,
+                name.as_ptr(),
+                bogus.as_ptr() as *const std::ffi::c_void,
+                version.as_ptr(),
+                &mut err,
+            )
+        };
+        assert_eq!(rc, DFG_ERR);
+        assert!(!err.is_null());
+        unsafe { dfgo_error_free(err) };
     }
 
     /// A null provider pointer is rejected rather than dereferenced.
@@ -1844,12 +1958,14 @@ mod tests {
             }),
         };
         let name = CString::new("t").unwrap();
+        let version = CString::new(datafusion_version_str()).unwrap();
         let mut err: *mut dfgo_error = ptr::null_mut();
         let rc = unsafe {
             dfgo_connection_register_ffi_table_provider(
                 &mut conn,
                 name.as_ptr(),
                 ptr::null(),
+                version.as_ptr(),
                 &mut err,
             )
         };

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -13,7 +13,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 use std::collections::{BTreeSet, HashMap};
-use std::ffi::{CStr, CString, c_char};
+use std::ffi::{CStr, CString, c_char, c_void};
 use std::fmt;
 use std::io::Cursor;
 use std::panic::{AssertUnwindSafe, catch_unwind};
@@ -28,11 +28,13 @@ use arrow::error::ArrowError;
 use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use arrow::ipc::reader::StreamReader;
 use arrow::record_batch::RecordBatch;
+use datafusion::catalog::TableProvider;
 use datafusion::common::{DataFusionError, ParamValues, ScalarValue};
 use datafusion::datasource::MemTable;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::execution::context::SessionConfig;
 use datafusion::prelude::SessionContext;
+use datafusion_ffi::table_provider::FFI_TableProvider;
 use datafusion_sql::parser::{DFParser, Statement as DFStatement};
 use datafusion_sql::sqlparser::ast::Statement as SQLStatement;
 use datafusion_sql::sqlparser::dialect::GenericDialect;
@@ -1378,6 +1380,45 @@ pub unsafe extern "C" fn dfgo_connection_register_arrow_stream(
     })
 }
 
+/// Register a foreign `datafusion-ffi` `FFI_TableProvider` produced by another
+/// library. `provider` points to an `FFI_TableProvider` (passed as an opaque
+/// `const void*` so the C header need not know datafusion-ffi's layout). The
+/// provider is imported via datafusion-ffi's `From<&FFI_TableProvider>`, which
+/// clones it — the caller retains ownership of `provider` and must free it.
+///
+/// # Safety
+///
+/// `conn` must be a live connection handle. `name` must be a valid
+/// NUL-terminated C string. `provider` must be a non-null pointer to a valid
+/// `FFI_TableProvider`. `err`, when non-null, must point to writable
+/// error-handle storage.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dfgo_connection_register_ffi_table_provider(
+    conn: *mut dfgo_connection,
+    name: *const c_char,
+    provider: *const c_void,
+    err: *mut *mut dfgo_error,
+) -> i32 {
+    run_ffi(err, || {
+        if conn.is_null() {
+            return Err(FfiError::invalid_argument("connection handle is null"));
+        }
+        if provider.is_null() {
+            return Err(FfiError::invalid_argument("provider handle is null"));
+        }
+        let name = cstr_to_string(name, "table name")?;
+        // SAFETY: `conn` is non-null and borrowed only for the duration of
+        // registration.
+        let conn = unsafe { &*conn };
+        // SAFETY: `provider` is non-null and, per the contract, points to a
+        // valid `FFI_TableProvider`. We only borrow it; `From` clones it.
+        let ffi_provider = unsafe { &*(provider as *const FFI_TableProvider) };
+        let table: Arc<dyn TableProvider> = ffi_provider.into();
+        conn.inner.ctx.register_table(&name, table)?;
+        Ok(())
+    })
+}
+
 /// # Safety
 ///
 /// `conn` must be a live connection handle. `query` must point to a valid
@@ -1722,6 +1763,100 @@ pub unsafe extern "C" fn dfgo_error_free(err: *mut dfgo_error) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Registering a foreign `FFI_TableProvider` makes it queryable by name.
+    #[test]
+    fn registers_and_queries_ffi_table_provider() {
+        use arrow::array::Int64Array;
+        use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+        use datafusion::execution::TaskContextProvider;
+        use datafusion_ffi::execution::FFI_TaskContextProvider;
+        use datafusion_ffi::table_provider::FFI_TableProvider;
+
+        // A one-column, three-row MemTable exported as an FFI_TableProvider.
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "a",
+            DataType::Int64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int64Array::from(vec![1_i64, 2, 3]))],
+        )
+        .expect("record batch");
+        let mem: Arc<dyn TableProvider> =
+            Arc::new(MemTable::try_new(schema, vec![vec![batch]]).expect("memtable"));
+
+        // FFI_TaskContextProvider holds a Weak, so this SessionContext must
+        // outlive the exported provider for the duration of the test.
+        let tcp_ctx = Arc::new(SessionContext::new());
+        let tcp = Arc::clone(&tcp_ctx) as Arc<dyn TaskContextProvider>;
+        let ffi =
+            FFI_TableProvider::new(mem, true, None, FFI_TaskContextProvider::from(&tcp), None);
+
+        // A minimal connection handle to register into.
+        let runtime = Arc::new(Runtime::new().expect("runtime"));
+        let mut conn = dfgo_connection {
+            inner: Arc::new(Inner {
+                runtime: Arc::clone(&runtime),
+                ctx: SessionContext::new(),
+            }),
+        };
+
+        // Exercise the exported C entry point exactly as Go calls it.
+        let name = CString::new("t").unwrap();
+        let mut err: *mut dfgo_error = ptr::null_mut();
+        let rc = unsafe {
+            dfgo_connection_register_ffi_table_provider(
+                &mut conn,
+                name.as_ptr(),
+                &ffi as *const FFI_TableProvider as *const std::ffi::c_void,
+                &mut err,
+            )
+        };
+        assert_eq!(rc, DFG_OK, "register returned an error");
+        assert!(err.is_null(), "register set an error");
+
+        // The registered provider is queryable, and a predicate filters rows.
+        let rows: usize = runtime
+            .block_on(async {
+                conn.inner
+                    .ctx
+                    .sql("SELECT a FROM t WHERE a > 1 ORDER BY a")
+                    .await?
+                    .collect()
+                    .await
+            })
+            .expect("query")
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
+        assert_eq!(rows, 2, "expected rows a=2,3");
+    }
+
+    /// A null provider pointer is rejected rather than dereferenced.
+    #[test]
+    fn rejects_null_ffi_table_provider() {
+        let mut conn = dfgo_connection {
+            inner: Arc::new(Inner {
+                runtime: Arc::new(Runtime::new().expect("runtime")),
+                ctx: SessionContext::new(),
+            }),
+        };
+        let name = CString::new("t").unwrap();
+        let mut err: *mut dfgo_error = ptr::null_mut();
+        let rc = unsafe {
+            dfgo_connection_register_ffi_table_provider(
+                &mut conn,
+                name.as_ptr(),
+                ptr::null(),
+                &mut err,
+            )
+        };
+        assert_eq!(rc, DFG_ERR);
+        assert!(!err.is_null());
+        unsafe { dfgo_error_free(err) };
+    }
 
     #[test]
     fn rewrites_question_marks_with_unicode_comments_and_multiline_sql() {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1487,9 +1487,7 @@ pub unsafe extern "C" fn dfgo_connection_register_ffi_table_provider(
         let expected = datafusion_version_str();
         if provider_version != expected {
             return Err(FfiError::invalid_argument(format!(
-                "incompatible FFI table provider: datafusion-go links datafusion \
-                 {expected}, but the provider reports {provider_version}; both sides \
-                 must link the same datafusion version"
+                "incompatible FFI table provider: datafusion-go links datafusion {expected}, but the provider reports {provider_version}; both sides must link the same datafusion version"
             )));
         }
 


### PR DESCRIPTION
Closes #12

About 1/3rd of this is Cargo.lock and about 1/3rd of what remains after that are tests in Rust.
I'm not sure if there is a nice way to break this up. I could probably do it in 2 PRs (rust side and go side) but they seem so coupled it might make it more confusing.

A little more on justification: We have a custom table provider, it's currently exposed to python. We were asked what it would take to expose it to go. I think with this PR the rest of the work is on our side.

Some references that are probably useful for you or your agent in review:
* Datafusion ffi: https://github.com/apache/datafusion/tree/main/datafusion/ffi
* Datafusion python (which uses FFI to add support for foreign table provider): https://github.com/apache/datafusion-python/tree/main/crates/core
* An FFI writeup: https://datafusion.apache.org/python/contributor-guide/ffi.html

Some notes about FFI here:
* Python uses a pycapsule approach to verify that the version of datafusion in the table provider and the code are aligned. We can't use that structure so we roll a similar one. I might open an issue on datafusion upstream to propose a more standard approach get added to the ffi tooling itself to avoid these downstream one offs.

Caveats:
* I have dabbled in Go but am definitely not a cgo expert so might be missing some approaches to shave off some sharp edges
* The unsafe pointer to the foreign table provider is a little unfortunate but I think it would have taken a tool I'm not familiar with in Go or a lot more machinery to abstract things properly. I poked at this a bit without too much luck.

