### PR TITLE
chore: prepare v0.530100.2 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to datafusion-go are documented here.
 
+## v0.530100.2 - 2026-07-19
+
+- Added foreign FFI table provider support: register a `datafusion-ffi` `FFI_TableProvider` produced by another library with `RegisterFFITableProvider` and query it with projection and filter pushdown reaching the provider. Returns a `*RegisteredTable` handle for explicit `Deregister`, with an exact `DataFusionVersion` handshake checked before the provider pointer is dereferenced.
+- Restructured the README in Apache DataFusion style.
+
 ## v0.530100.1 - 2026-06-05
 
 Initial release for Apache DataFusion 53.1.0.

--- a/internal/native/version_generated.go
+++ b/internal/native/version_generated.go
@@ -5,4 +5,4 @@ package native
 
 const abiVersion = 1
 const dataFusionVersion = "53.1.0"
-const dataFusionGoVersion = "0.530100.1"
+const dataFusionGoVersion = "0.530100.2"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-go"
-version = "0.530100.1"
+version = "0.530100.2"
 dependencies = [
  "arrow",
  "datafusion",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datafusion-go"
-version = "0.530100.1"
+version = "0.530100.2"
 edition = "2024"
 rust-version = "1.88"
 

--- a/version.go
+++ b/version.go
@@ -13,8 +13,8 @@ const (
 	DataFusionGoMajor = 0
 
 	// DataFusionGoPatch is the patch component of datafusion-go release tags.
-	DataFusionGoPatch = 1
+	DataFusionGoPatch = 2
 
 	// DataFusionGoVersion is the full datafusion-go module version without the leading v.
-	DataFusionGoVersion = "0.530100.1"
+	DataFusionGoVersion = "0.530100.2"
 )

--- a/versions.toml
+++ b/versions.toml
@@ -9,7 +9,7 @@ version = "53.1.0"
 # Release tags are v<major>.<encoded-datafusion-version>.<patch>.
 # DataFusion 53.1.0 with major 0 and patch 1 becomes v0.530100.1.
 major = 0
-patch = 1
+patch = 2
 
 [abi]
 # Increment when the C ABI shared by Rust, C, and Go changes incompatibly.


### PR DESCRIPTION
Bump datafusion_go.patch 1 -> 2 in versions.toml and regenerate the mechanical version outputs (version.go, internal/native/version_generated.go, rust/Cargo.toml, rust/Cargo.lock) via `make generate`. DataFusion stays pinned at 53.1.0.

Add the CHANGELOG.md entry for v0.530100.2 covering foreign FFI table provider support (RegisterFFITableProvider) and the README restructure. `make changelog.check` validates the entry for the derived release tag.

Not CRITICAL but a nice to have so I can point at a released artifact for downstream work.