### PR TITLE
Prepare v0.530100.2 and enforce release bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -36,6 +37,9 @@ jobs:
 
       - name: Changelog has an entry for the release tag
         run: make changelog.check
+
+      - name: Release-relevant changes have a new version
+        run: make release.check
 
       - name: No-cgo unsupported path
         run: make go.test.nocgo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to datafusion-go are documented here.
 
+## v0.530100.2 - 2026-07-25
+
+- Added registration and explicit deregistration of foreign `datafusion-ffi`
+  table providers, including exact DataFusion version validation and
+  projection/filter pushdown support.
+- Improved the README and contributor guidance for the database/sql, Arrow,
+  native-runtime, and release workflows.
+- Hardened release automation against GitHub tag-visibility lag and added a CI
+  guard that requires a new version before release-relevant changes can merge.
+
 ## v0.530100.1 - 2026-06-05
 
 Initial release for Apache DataFusion 53.1.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,12 @@ non-empty body; `make changelog.check` validates this and runs in CI, and the
 release workflow extracts the release notes from that entry. Releases
 are cut only by GitHub Actions after the `CI` workflow completes successfully on
 `main`, using the default workflow token; no extra credentials are required.
+CI also runs `make release.check`: when the tag derived from `versions.toml`
+already exists, any release-relevant change since that tag fails the build and
+must increment the version before merging. Documentation, examples, tests, and
+GitHub workflow/configuration changes do not require a module release. The
+tag-only checksum manifest is also excluded because `main` intentionally keeps
+the placeholder described below.
 
 The `Release` workflow derives the tag from `versions.toml`. If that tag already
 exists, the workflow exits without publishing. Otherwise, it downloads the

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ else ifeq ($(GOOS),windows)
 STRIP_SHARED := strip --strip-unneeded
 endif
 
-.PHONY: generate generate.check rust.build rust.test rust.lint bundle checksum.native checksums verify.checksums changelog.check stage.release.assets verify.release.assets go.lint go.vet go.test.dynamic go.test.bundled go.test.race go.test.source go.test.nocgo test test.source lint consumer.smoke release.verify clean
+.PHONY: generate generate.check release.check rust.build rust.test rust.lint bundle checksum.native checksums verify.checksums changelog.check stage.release.assets verify.release.assets go.lint go.vet go.test.dynamic go.test.bundled go.test.race go.test.source go.test.nocgo test test.source lint consumer.smoke release.verify clean
 
 generate:
 	go run ./internal/tools/genversions
@@ -49,6 +49,9 @@ generate:
 generate.check:
 	go run ./internal/tools/genversions -check
 	cargo metadata --manifest-path rust/Cargo.toml --locked --format-version 1 >/dev/null
+
+release.check:
+	go run ./internal/tools/genversions -check-release
 
 rust.build: generate.check
 	$(RUST_BUILD_ENV) cargo build --manifest-path rust/Cargo.toml --release $(RUST_TARGET_FLAG)

--- a/internal/native/version_generated.go
+++ b/internal/native/version_generated.go
@@ -5,4 +5,4 @@ package native
 
 const abiVersion = 1
 const dataFusionVersion = "53.1.0"
-const dataFusionGoVersion = "0.530100.1"
+const dataFusionGoVersion = "0.530100.2"

--- a/internal/tools/genversions/main.go
+++ b/internal/tools/genversions/main.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -23,12 +26,23 @@ type config struct {
 
 func main() {
 	check := flag.Bool("check", false, "check generated files without writing")
+	checkRelease := flag.Bool("check-release", false, "require a new tag when release-relevant files changed")
 	githubOutput := flag.String("github-output", "", "append computed release values to a GitHub Actions output file")
 	flag.Parse()
 
 	cfg, err := readConfig("versions.toml")
 	if err != nil {
 		fatal(err)
+	}
+
+	if *checkRelease {
+		if *check || *githubOutput != "" {
+			fatal(errors.New("-check-release cannot be combined with -check or -github-output"))
+		}
+		if err := checkReleaseNovelty(cfg); err != nil {
+			fatal(err)
+		}
+		return
 	}
 
 	if *githubOutput != "" {
@@ -217,6 +231,94 @@ func (cfg config) dataFusionGoVersion() string {
 
 func (cfg config) releaseTag() string {
 	return "v" + cfg.dataFusionGoVersion()
+}
+
+func checkReleaseNovelty(cfg config) error {
+	shallow, err := gitOutput("rev-parse", "--is-shallow-repository")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(shallow) == "true" {
+		return errors.New("release check requires complete Git history and tags; fetch with --unshallow --tags")
+	}
+
+	tag := cfg.releaseTag()
+	if _, err := gitOutput("rev-parse", "-q", "--verify", "refs/tags/"+tag+"^{commit}"); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			fmt.Printf("release tag %s is new\n", tag)
+			return nil
+		}
+		return err
+	}
+
+	changed, err := gitOutputBytes("diff", "--name-only", "-z", "refs/tags/"+tag+"^{commit}", "--")
+	if err != nil {
+		return err
+	}
+
+	var relevant []string
+	for _, raw := range bytes.Split(changed, []byte{0}) {
+		if len(raw) == 0 {
+			continue
+		}
+		path := filepath.ToSlash(string(raw))
+		if releaseRelevantPath(path) {
+			relevant = append(relevant, path)
+		}
+	}
+	if len(relevant) == 0 {
+		fmt.Printf("release tag %s already exists; no release-relevant files changed\n", tag)
+		return nil
+	}
+
+	slices.Sort(relevant)
+	return fmt.Errorf(
+		"release tag %s already exists, but release-relevant files changed since it:\n  %s\nincrement the release in versions.toml, run `make generate`, and update CHANGELOG.md",
+		tag,
+		strings.Join(relevant, "\n  "),
+	)
+}
+
+func gitOutput(args ...string) (string, error) {
+	output, err := gitOutputBytes(args...)
+	return string(output), err
+}
+
+func gitOutputBytes(args ...string) ([]byte, error) {
+	cmd := exec.Command("git", args...)
+	output, err := cmd.Output()
+	if err == nil {
+		return output, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) != 0 {
+		return nil, fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(exitErr.Stderr)), err)
+	}
+	return nil, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+}
+
+func releaseRelevantPath(path string) bool {
+	switch path {
+	case ".gitattributes",
+		".gitignore",
+		".golangci.yml",
+		"AGENTS.md",
+		"CHANGELOG.md",
+		"CONTRIBUTING.md",
+		"LICENSE",
+		"README.md",
+		"internal/native/lib/SHA256SUMS":
+		return false
+	}
+
+	for _, prefix := range []string{".github/", "docs/", "examples/"} {
+		if strings.HasPrefix(path, prefix) {
+			return false
+		}
+	}
+
+	return !strings.HasSuffix(path, "_test.go")
 }
 
 func plannedUpdates(cfg config) (map[string][]byte, error) {

--- a/internal/tools/genversions/main_test.go
+++ b/internal/tools/genversions/main_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReleaseRelevantPath(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]bool{
+		"datafusion.go":                      true,
+		"ffi_table_provider.go":              true,
+		"ffi_table_provider_test.go":         false,
+		"go.mod":                             true,
+		"internal/native/native.go":          true,
+		"internal/native/lib/SHA256SUMS":     false,
+		"internal/tools/genversions/main.go": true,
+		"rust/Cargo.toml":                    true,
+		"rust/src/lib.rs":                    true,
+		"versions.toml":                      true,
+		".github/workflows/release.yml":      false,
+		"docs/architecture.md":               false,
+		"examples/simple/main.go":            false,
+		"CHANGELOG.md":                       false,
+		"CONTRIBUTING.md":                    false,
+		"README.md":                          false,
+	}
+
+	for path, want := range tests {
+		path, want := path, want
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			if got := releaseRelevantPath(path); got != want {
+				t.Fatalf("releaseRelevantPath(%q) = %v, want %v", path, got, want)
+			}
+		})
+	}
+}
+
+func TestCheckReleaseNovelty(t *testing.T) {
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+	runGit(t, repo, "config", "user.name", "Release Test")
+	runGit(t, repo, "config", "user.email", "release-test@example.com")
+
+	writeTestFile(t, repo, "datafusion.go", "package datafusion\n")
+	runGit(t, repo, "add", "datafusion.go")
+	runGit(t, repo, "commit", "-m", "initial")
+
+	cfg := config{
+		DataFusionVersion: "53.1.0",
+		GoMajor:           0,
+		GoPatch:           1,
+	}
+	runGit(t, repo, "tag", cfg.releaseTag())
+
+	restore := chdir(t, repo)
+	defer restore()
+
+	if err := checkReleaseNovelty(cfg); err != nil {
+		t.Fatalf("checkReleaseNovelty() at tag: %v", err)
+	}
+
+	writeTestFile(t, repo, "README.md", "documentation\n")
+	if err := checkReleaseNovelty(cfg); err != nil {
+		t.Fatalf("checkReleaseNovelty() with documentation change: %v", err)
+	}
+
+	writeTestFile(t, repo, "datafusion.go", "package datafusion\n\nconst changed = true\n")
+	err := checkReleaseNovelty(cfg)
+	if err == nil {
+		t.Fatal("checkReleaseNovelty() with code change succeeded, want error")
+	}
+	if message := err.Error(); !strings.Contains(message, cfg.releaseTag()) || !strings.Contains(message, "datafusion.go") {
+		t.Fatalf("checkReleaseNovelty() error = %q, want tag and changed path", message)
+	}
+
+	cfg.GoPatch = 2
+	if err := checkReleaseNovelty(cfg); err != nil {
+		t.Fatalf("checkReleaseNovelty() with a new tag: %v", err)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func writeTestFile(t *testing.T, root, name, contents string) {
+	t.Helper()
+	path := filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func chdir(t *testing.T, dir string) func() {
+	t.Helper()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	return func() {
+		if err := os.Chdir(previous); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	}
+}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-go"
-version = "0.530100.1"
+version = "0.530100.2"
 dependencies = [
  "arrow",
  "datafusion",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datafusion-go"
-version = "0.530100.1"
+version = "0.530100.2"
 edition = "2024"
 rust-version = "1.88"
 

--- a/version.go
+++ b/version.go
@@ -13,8 +13,8 @@ const (
 	DataFusionGoMajor = 0
 
 	// DataFusionGoPatch is the patch component of datafusion-go release tags.
-	DataFusionGoPatch = 1
+	DataFusionGoPatch = 2
 
 	// DataFusionGoVersion is the full datafusion-go module version without the leading v.
-	DataFusionGoVersion = "0.530100.1"
+	DataFusionGoVersion = "0.530100.2"
 )

--- a/versions.toml
+++ b/versions.toml
@@ -9,7 +9,7 @@ version = "53.1.0"
 # Release tags are v<major>.<encoded-datafusion-version>.<patch>.
 # DataFusion 53.1.0 with major 0 and patch 1 becomes v0.530100.1.
 major = 0
-patch = 1
+patch = 2
 
 [abi]
 # Increment when the C ABI shared by Rust, C, and Go changes incompatibly.


### PR DESCRIPTION
## Summary

- prepare v0.530100.2 with generated Go/Rust version metadata and release notes
- fail CI when release-relevant source differs from an already-existing derived tag
- exempt documentation, examples, tests, GitHub configuration, and the tag-only checksum manifest
- test both existing-tag and new-tag behavior

## Verification

- make generate.check
- make changelog.check
- make release.check
- make lint
- make test
- make test.source
- make rust.test