### PR TITLE
Fix native resource handling and library loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to datafusion-go are documented here.
 
+## v0.550000.1 - 2026-09-06
+
+- Fixed Arrow reader callback panics leaking imported buffers, premature reader finalization during active reads, and native connection access racing with close or session reset.
+- Hardened automatic native library loading with canonical path, ownership, permission, and platform ACL checks. Explicit library paths must now be absolute; downloads and redirects require HTTPS, and native asset sizes are bounded. Restricted Windows DLL dependency searches and disabled runtime loading for privileged processes.
+- Rejected embedded NULs before C-string conversion and oversized parameter ordinals before allocation. Sanitized NULs in streamed execution errors to prevent native process aborts.
+- Added memory, concurrency, callback, and loader security regression tests, and documented process isolation requirements for untrusted SQL and native providers.
+
 ## v0.550000.0 - 2026-09-05
 
 - Upgraded bundled Apache DataFusion to 55.0.0 and Arrow Rust to 59.3.0. Foreign table providers must be built with `datafusion-ffi` 55.0.0; the exact version handshake rejects older providers before dereferencing their pointers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ session/runtime destruction with Rust weak references and Arrow buffer release
 with a checked C allocator, including cancellation, reset, and registration
 failures. Go's race detector supplements these allocation checks.
 
+Security regression tests cover panicking Arrow reader callbacks with a checked C allocator, GC during an active read, concurrent connection close/reset, and writable native-library paths (including macOS and Windows ACLs). On Linux, `TestSecureExecutionWithCapabilitiesWithoutProc` additionally exercises a non-root executable with a file capability after chroot removes `/proc`. That fixture requires root and `setcap`; run it in a disposable container. It skips on ordinary non-root test runs.
+
 The Rust build, test, and lint targets use the same macOS deployment settings
 so switching targets does not invalidate native dependency builds.
 

--- a/README.md
+++ b/README.md
@@ -485,6 +485,8 @@ Nested and complex Arrow values such as lists, structs, maps, unions, dictionari
 - `Close` is idempotent for connectors, connections, statements, rows, and Arrow readers.
 - Transactions are unsupported and return explicit unsupported errors. `BeginTx` still honors an already-canceled context before returning the unsupported transaction error.
 
+SQL executes with the host process's filesystem and network permissions. Isolated sessions separate catalogs; they are not a sandbox for hostile SQL or native FFI providers. Run untrusted workloads in a separate process with restricted OS permissions and resource limits.
+
 ### Native Runtime
 
 Default builds use cgo but do not link DataFusion at Go link time. At runtime, the driver loads a shared `libdatafusion_go` library, resolved in this order:
@@ -495,9 +497,11 @@ Default builds use cgo but do not link DataFusion at Go link time. At runtime, t
 
 Environment variables:
 
-- `DATAFUSION_GO_LIBRARY` — explicit path to the shared library.
+- `DATAFUSION_GO_LIBRARY` — explicit absolute path to a trusted shared library.
 - `DATAFUSION_GO_NO_DOWNLOAD=1` — disable automatic release-asset downloads.
-- `DATAFUSION_GO_DOWNLOAD_BASE` — override the release download base URL.
+- `DATAFUSION_GO_DOWNLOAD_BASE` — override the release download base with an HTTPS URL. Redirects must also use HTTPS.
+
+Automatic source and cache resolution checks the library and its ancestors for ownership and write permissions. Keep these directories private to the service account or system administrators. Explicit library paths are trusted configuration and bypass automatic permission checks. Setuid, setgid, and Linux file-capability processes must use a library linked at build time (`datafusion_use_bundled` or `datafusion_use_source`); runtime resolution is disabled for them.
 
 Prebuilt native libraries are published for `darwin-arm64`, `darwin-amd64`, `linux-amd64`, `linux-arm64`, and `windows-amd64`. Windows arm64 is not currently bundled.
 

--- a/arrow.go
+++ b/arrow.go
@@ -13,6 +13,8 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/arrio"
 	"github.com/apache/arrow-go/v18/arrow/ipc"
+
+	"github.com/datafusion-contrib/datafusion-go/internal/native"
 )
 
 // ArrowReader streams Arrow record batches returned by DataFusion.
@@ -90,7 +92,9 @@ func RegisterArrowReader(ctx context.Context, sqlConn *sql.Conn, tableName strin
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		return conn.conn.RegisterArrowIPC(tableName, data.Bytes())
+		return conn.withNative(func(nc *native.Connection) error {
+			return nc.RegisterArrowIPC(tableName, data.Bytes())
+		})
 	})
 }
 
@@ -114,7 +118,9 @@ func RegisterArrowReaderZeroCopy(ctx context.Context, sqlConn *sql.Conn, tableNa
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		return conn.conn.RegisterArrowReaderZeroCopy(tableName, reader)
+		return conn.withNative(func(nc *native.Connection) error {
+			return nc.RegisterArrowReaderZeroCopy(tableName, reader)
+		})
 	})
 }
 
@@ -201,6 +207,20 @@ func newSerializedArrowReader(reader ArrowReader, unlock func()) ArrowReader {
 	serialized := &serializedArrowReader{ArrowReader: reader, unlock: unlock}
 	runtime.SetFinalizer(serialized, (*serializedArrowReader).finalize)
 	return serialized
+}
+
+// Keep the wrapper alive during delegated calls so its finalizer cannot close
+// an active reader. Promoted methods on the embedded interface do not do this.
+func (reader *serializedArrowReader) Read() (arrow.RecordBatch, error) {
+	rec, err := reader.ArrowReader.Read()
+	runtime.KeepAlive(reader)
+	return rec, err
+}
+
+func (reader *serializedArrowReader) Schema() *arrow.Schema {
+	schema := reader.ArrowReader.Schema()
+	runtime.KeepAlive(reader)
+	return schema
 }
 
 func (reader *serializedArrowReader) Close() error {

--- a/connection.go
+++ b/connection.go
@@ -219,17 +219,23 @@ func (conn *Conn) queryArrowContext(ctx context.Context, query string, args []dr
 	if err := ctx.Err(); err != nil {
 		return nil, nil, err
 	}
-	if err := conn.checkOpen(); err != nil {
-		return nil, nil, err
-	}
 	named, err := normalizeNamedValueSlice(args)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	stmt, err := conn.conn.Prepare(query)
-	if err != nil {
-		return nil, nil, driverError(ErrorPrepare, "could not prepare DataFusion statement", err)
+	// Once prepared, the statement owns its session reference and can execute
+	// outside conn.mu.
+	var stmt *native.Statement
+	if err := conn.withNative(func(nc *native.Connection) error {
+		prepared, err := nc.Prepare(query)
+		if err != nil {
+			return driverError(ErrorPrepare, "could not prepare DataFusion statement", err)
+		}
+		stmt = prepared
+		return nil
+	}); err != nil {
+		return nil, nil, err
 	}
 	defer stmt.Close()
 
@@ -272,6 +278,18 @@ func (conn *Conn) checkOpen() error {
 		return driverError(ErrorClosed, "datafusion connection is closed", nil)
 	}
 	return nil
+}
+
+// withNative prevents Close or ResetSession from freeing the native handle
+// during fn. All access to conn.conn must hold conn.mu.
+func (conn *Conn) withNative(fn func(*native.Connection) error) error {
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+
+	if conn.closed || conn.conn == nil {
+		return driverError(ErrorClosed, "datafusion connection is closed", nil)
+	}
+	return fn(conn.conn)
 }
 
 var _ driver.Conn = (*Conn)(nil)

--- a/ffi_table_provider.go
+++ b/ffi_table_provider.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"sync"
 	"unsafe"
+
+	"github.com/datafusion-contrib/datafusion-go/internal/native"
 )
 
 // RegisteredTable is a handle to a table registered on a connection by
@@ -89,7 +91,9 @@ func RegisterFFITableProvider(ctx context.Context, sqlConn *sql.Conn, tableName 
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		return conn.conn.RegisterFFITableProvider(tableName, provider, providerDataFusionVersion)
+		return conn.withNative(func(nc *native.Connection) error {
+			return nc.RegisterFFITableProvider(tableName, provider, providerDataFusionVersion)
+		})
 	}); err != nil {
 		return nil, err
 	}
@@ -123,7 +127,9 @@ func (t *RegisteredTable) Deregister(ctx context.Context) error {
 	}
 
 	if err := withDataFusionConn(t.sqlConn, func(conn *Conn) error {
-		return conn.conn.DeregisterTable(t.name)
+		return conn.withNative(func(nc *native.Connection) error {
+			return nc.DeregisterTable(t.name)
+		})
 	}); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,10 @@ go 1.25.0
 
 toolchain go1.27.1
 
-require github.com/apache/arrow-go/v18 v18.5.1
+require (
+	github.com/apache/arrow-go/v18 v18.5.1
+	golang.org/x/sys v0.44.0
+)
 
 require (
 	github.com/goccy/go-json v0.10.5 // indirect
@@ -16,7 +19,6 @@ require (
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260109210033-bd525da824e2 // indirect
 	golang.org/x/tools v0.41.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/internal/native/dynamic_loader.h
+++ b/internal/native/dynamic_loader.h
@@ -3,11 +3,19 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+/* Available since Windows 8 / KB2533623; define for older toolchain headers. */
+#ifndef LOAD_LIBRARY_SEARCH_SYSTEM32
+#define LOAD_LIBRARY_SEARCH_SYSTEM32 0x00000800
+#endif
+#ifndef LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR
+#define LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR 0x00000100
+#endif
 static HMODULE dfgo_dynamic_handle = NULL;
 #else
 #include <dlfcn.h>
@@ -121,9 +129,27 @@ static int dfgo_native_load_library(const char *path) {
 	}
 
 #ifdef _WIN32
-	dfgo_dynamic_handle = LoadLibraryA(path);
+	/* Preserve UTF-8 paths and restrict dependencies to the DLL's directory
+	 * and System32. */
+	{
+		int wide_len = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, NULL, 0);
+		wchar_t *wide = NULL;
+		if (wide_len <= 0) {
+			dfgo_set_dynamic_error("could not load library", "path is not valid UTF-8");
+			return -1;
+		}
+		wide = (wchar_t *)malloc((size_t)wide_len * sizeof(wchar_t));
+		if (wide == NULL) {
+			dfgo_set_dynamic_error("could not load library", "out of memory");
+			return -1;
+		}
+		MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, wide, wide_len);
+		dfgo_dynamic_handle = LoadLibraryExW(wide, NULL,
+			LOAD_LIBRARY_SEARCH_SYSTEM32 | LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR);
+		free(wide);
+	}
 	if (dfgo_dynamic_handle == NULL) {
-		snprintf(dfgo_dynamic_error, sizeof(dfgo_dynamic_error), "LoadLibraryA failed with error %lu", (unsigned long)GetLastError());
+		snprintf(dfgo_dynamic_error, sizeof(dfgo_dynamic_error), "LoadLibraryExW failed with error %lu", (unsigned long)GetLastError());
 		return -1;
 	}
 #else

--- a/internal/native/library.go
+++ b/internal/native/library.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -29,7 +30,19 @@ const (
 var nativeChecksumManifest string
 
 func resolveNativeLibrary() (string, error) {
+	return resolveNativeLibraryForExecution(secureExecution())
+}
+
+func resolveNativeLibraryForExecution(privileged bool) (string, error) {
+	// User-owned source and cache paths are not a trust boundary for setgid or
+	// file-capability programs, even if their effective UID is unchanged.
+	if privileged {
+		return "", errors.New("datafusion-go runtime library loading is disabled for privileged execution; use datafusion_use_bundled or datafusion_use_source")
+	}
 	if path := os.Getenv(nativeLibraryEnv); path != "" {
+		if !filepath.IsAbs(path) {
+			return "", fmt.Errorf("%s must be an absolute path, got %q", nativeLibraryEnv, path)
+		}
 		return path, nil
 	}
 	if path, ok := localNativeLibrary(); ok {
@@ -43,7 +56,8 @@ func resolveNativeLibrary() (string, error) {
 
 func localNativeLibrary() (string, bool) {
 	_, file, _, ok := runtime.Caller(0)
-	if !ok {
+	// -trimpath produces relative paths; probing those would trust the CWD.
+	if !ok || !filepath.IsAbs(file) {
 		return "", false
 	}
 	name, err := nativeSharedLibraryName()
@@ -51,8 +65,8 @@ func localNativeLibrary() (string, bool) {
 		return "", false
 	}
 	path := filepath.Join(filepath.Dir(file), "lib", nativePlatform(), name)
-	if regularFile(path) {
-		return path, true
+	if resolved, err := trustedNativePath(path, false); err == nil {
+		return resolved, true
 	}
 	return "", false
 }
@@ -72,13 +86,26 @@ func downloadNativeLibrary() (string, error) {
 		return "", fmt.Errorf("could not locate user cache directory for datafusion-go native library: %w", err)
 	}
 	dir := filepath.Join(cacheDir, nativeDownloadCacheName, "v"+dataFusionGoVersion)
-	path := filepath.Join(dir, asset)
-	if err := verifyFileSHA256(path, want); err == nil {
-		return path, nil
-	}
-
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", fmt.Errorf("could not create datafusion-go native cache directory: %w", err)
+	}
+	dir, err = trustedNativePath(dir, true)
+	if err != nil {
+		return "", fmt.Errorf("refusing to use datafusion-go native cache directory: %w", err)
+	}
+	path := filepath.Join(dir, asset)
+	if info, err := os.Lstat(path); err == nil && !info.Mode().IsRegular() {
+		return "", fmt.Errorf("cached native library is not a regular file: %s", path)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	if resolved, err := trustedNativePath(path, false); err == nil {
+		path = resolved
+		if err := verifyFileSHA256(path, want); err == nil {
+			return path, nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("refusing to use cached native library: %w", err)
 	}
 	tmp, err := os.CreateTemp(dir, asset+".*.tmp")
 	if err != nil {
@@ -89,8 +116,18 @@ func downloadNativeLibrary() (string, error) {
 		_ = os.Remove(tmpPath)
 	}()
 
-	url := nativeDownloadURL(asset)
-	if err := downloadFile(tmp, url); err != nil {
+	// Inherited ACLs can make a newly created file writable even in a
+	// directory whose own permissions passed. Check before writing any bytes.
+	if _, err := trustedNativePath(tmpPath, false); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("unsafe native download file: %w", err)
+	}
+	downloadURL, err := nativeDownloadURL(asset)
+	if err != nil {
+		_ = tmp.Close()
+		return "", err
+	}
+	if err := downloadFile(tmp, downloadURL); err != nil {
 		_ = tmp.Close()
 		return "", err
 	}
@@ -103,25 +140,44 @@ func downloadNativeLibrary() (string, error) {
 	if err := os.Chmod(tmpPath, 0o755); err != nil {
 		return "", fmt.Errorf("could not mark datafusion-go native library executable: %w", err)
 	}
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return "", fmt.Errorf("could not replace cached datafusion-go native library: %w", err)
-	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		return "", fmt.Errorf("could not install datafusion-go native library in cache: %w", err)
 	}
 	return path, nil
 }
 
-func nativeDownloadURL(asset string) string {
+func nativeDownloadURL(asset string) (string, error) {
 	base := os.Getenv(nativeDownloadBaseEnv)
 	if base == "" {
 		base = "https://github.com/datafusion-contrib/datafusion-go/releases/download/v" + dataFusionGoVersion
+	} else {
+		parsed, err := url.Parse(base)
+		if err != nil {
+			return "", fmt.Errorf("invalid %s %q: %w", nativeDownloadBaseEnv, base, err)
+		}
+		if parsed.Scheme != "https" || parsed.Host == "" {
+			return "", fmt.Errorf("%s must be an https:// URL with a host, got %q", nativeDownloadBaseEnv, base)
+		}
 	}
-	return strings.TrimRight(base, "/") + "/" + asset
+	return strings.TrimRight(base, "/") + "/" + asset, nil
 }
 
+// Bound disk use before an oversized download can fail checksum verification.
+const maxNativeAssetSize = 512 << 20
+
 func downloadFile(dst *os.File, url string) error {
-	client := http.Client{Timeout: 10 * time.Minute}
+	client := http.Client{
+		Timeout: 10 * time.Minute,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if req.URL.Scheme != "https" {
+				return errors.New("native library download redirect must use HTTPS")
+			}
+			if len(via) >= 10 {
+				return errors.New("too many native library download redirects")
+			}
+			return nil
+		},
+	}
 	resp, err := client.Get(url)
 	if err != nil {
 		return fmt.Errorf("could not download datafusion-go native library %s: %w", url, err)
@@ -132,8 +188,15 @@ func downloadFile(dst *os.File, url string) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("could not download datafusion-go native library %s: HTTP %s", url, resp.Status)
 	}
-	if _, err := io.Copy(dst, resp.Body); err != nil {
+	if resp.ContentLength > maxNativeAssetSize {
+		return fmt.Errorf("datafusion-go native library download is %d bytes, above the %d byte limit", resp.ContentLength, maxNativeAssetSize)
+	}
+	written, err := io.Copy(dst, io.LimitReader(resp.Body, maxNativeAssetSize+1))
+	if err != nil {
 		return fmt.Errorf("could not write datafusion-go native library download: %w", err)
+	}
+	if written > maxNativeAssetSize {
+		return fmt.Errorf("datafusion-go native library download exceeds the %d byte limit", maxNativeAssetSize)
 	}
 	return nil
 }
@@ -188,8 +251,16 @@ func verifyFileSHA256(path string, want string) error {
 	defer func() {
 		_ = file.Close()
 	}()
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() || info.Size() > maxNativeAssetSize {
+		return fmt.Errorf("native library must be a regular file no larger than %d bytes: %s", maxNativeAssetSize, path)
+	}
 	hash := sha256.New()
-	if _, err := io.Copy(hash, file); err != nil {
+	// Bound reads too, in case a cache file grows after Stat.
+	if _, err := io.Copy(hash, io.LimitReader(file, maxNativeAssetSize+1)); err != nil {
 		return err
 	}
 	got := hex.EncodeToString(hash.Sum(nil))
@@ -197,12 +268,4 @@ func verifyFileSHA256(path string, want string) error {
 		return fmt.Errorf("sha256 mismatch for %s: got %s, want %s", path, got, want)
 	}
 	return nil
-}
-
-func regularFile(path string) bool {
-	info, err := os.Stat(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return false
-	}
-	return err == nil && info.Mode().IsRegular()
 }

--- a/internal/native/library_acl_darwin.go
+++ b/internal/native/library_acl_darwin.go
@@ -1,0 +1,71 @@
+//go:build cgo && darwin
+
+package native
+
+/*
+#include <errno.h>
+#include <membership.h>
+#include <stdlib.h>
+#include <sys/acl.h>
+#include <unistd.h>
+
+static int dfgo_check_native_acl(const char *path, int directory, int library_directory) {
+    acl_t acl = acl_get_file(path, ACL_TYPE_EXTENDED);
+    if (acl == NULL) return (errno == ENOTSUP || errno == ENOENT) ? 0 : errno;
+    int result = 0;
+    acl_entry_t entry;
+    int entry_id = ACL_FIRST_ENTRY;
+    while (acl_get_entry(acl, entry_id, &entry) == 0) {
+        entry_id = ACL_NEXT_ENTRY;
+        acl_tag_t tag;
+        acl_permset_t perms;
+        acl_flagset_t flags;
+        if (acl_get_tag_type(entry, &tag) != 0 ||
+            acl_get_permset(entry, &perms) != 0 ||
+            acl_get_flagset_np(entry, &flags) != 0) { result = EACCES; break; }
+        if (tag == ACL_EXTENDED_DENY || acl_get_flag_np(flags, ACL_ENTRY_ONLY_INHERIT) == 1) continue;
+        if (tag != ACL_EXTENDED_ALLOW) { result = EACCES; break; }
+        // Adding new children alone does not replace existing protected ones.
+        int writes = acl_get_perm_np(perms, ACL_DELETE) ||
+            acl_get_perm_np(perms, ACL_WRITE_SECURITY) ||
+            acl_get_perm_np(perms, ACL_CHANGE_OWNER);
+        if (directory) {
+            writes |= acl_get_perm_np(perms, ACL_DELETE_CHILD);
+            if (library_directory) writes |= acl_get_perm_np(perms, ACL_ADD_FILE) || acl_get_perm_np(perms, ACL_ADD_SUBDIRECTORY);
+        }
+        else writes |= acl_get_perm_np(perms, ACL_WRITE_DATA) || acl_get_perm_np(perms, ACL_APPEND_DATA);
+        if (!writes) continue;
+        uuid_t *qualifier = (uuid_t *)acl_get_qualifier(entry);
+        id_t id = 0;
+        int type = -1;
+        int trusted = qualifier != NULL && mbr_uuid_to_id(*qualifier, &id, &type) == 0 &&
+            type == ID_TYPE_UID && (id == 0 || id == geteuid());
+        if (qualifier != NULL) acl_free(qualifier);
+        if (!trusted) { result = EACCES; break; }
+    }
+    acl_free(acl);
+    return result;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+func checkNativeACLPermissions(path string, directory, libraryDirectory bool) error {
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+	var dir, private C.int
+	if directory {
+		dir = 1
+	}
+	if libraryDirectory {
+		private = 1
+	}
+	if errno := C.dfgo_check_native_acl(cpath, dir, private); errno != 0 {
+		return fmt.Errorf("native path has an unsafe or unreadable ACL: %s (errno %d)", path, int(errno))
+	}
+	return nil
+}

--- a/internal/native/library_acl_darwin_test.go
+++ b/internal/native/library_acl_darwin_test.go
@@ -1,0 +1,52 @@
+//go:build cgo && darwin
+
+package native
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNativePathRejectsExtendedACLWrites(t *testing.T) {
+	for _, target := range []string{"parent", "file"} {
+		t.Run(target, func(t *testing.T) {
+			parent := filepath.Join(t.TempDir(), "cache")
+			dir := filepath.Join(parent, "version")
+			if err := os.MkdirAll(dir, 0700); err != nil {
+				t.Fatal(err)
+			}
+			file := filepath.Join(dir, "native")
+			if err := os.WriteFile(file, []byte("library"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := trustedNativePath(file, false); err != nil {
+				t.Fatal(err)
+			}
+			path, permission := parent, "delete_child"
+			if target == "file" {
+				path, permission = file, "write"
+			}
+			if out, err := exec.Command("chmod", "+a", "everyone allow "+permission, path).CombinedOutput(); err != nil {
+				t.Fatalf("set ACL: %v: %s", err, out)
+			}
+			t.Cleanup(func() {
+				if out, err := exec.Command("chmod", "-N", path).CombinedOutput(); err != nil {
+					t.Errorf("remove ACL: %v: %s", err, out)
+				}
+			})
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Mode().Perm()&0022 != 0 {
+				t.Fatal("fixture unexpectedly changed POSIX write bits")
+			}
+			if _, err := trustedNativePath(file, false); err == nil || !strings.Contains(err.Error(), "ACL") {
+				t.Fatalf("accepted writable ACL on %s: %v", target, err)
+			}
+		})
+	}
+}

--- a/internal/native/library_acl_unix.go
+++ b/internal/native/library_acl_unix.go
@@ -1,0 +1,8 @@
+//go:build cgo && unix && !darwin
+
+package native
+
+// POSIX access ACLs are constrained by the group-class permission bits already
+// checked in checkNativePathPermissions. macOS extended ACLs need a separate
+// check because they can grant writes without changing those bits.
+func checkNativeACLPermissions(string, bool, bool) error { return nil }

--- a/internal/native/library_trust.go
+++ b/internal/native/library_trust.go
@@ -1,0 +1,45 @@
+//go:build cgo
+
+package native
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// trustedNativePath resolves symlinks and checks the resulting path from the
+// root down. Returning the resolved path is essential: loading via the original
+// symlink would let its owner redirect the load after verification.
+func trustedNativePath(path string, directory bool) (string, error) {
+	if !filepath.IsAbs(path) {
+		return "", fmt.Errorf("native path must be absolute: %q", path)
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	var ancestors []string
+	for p := resolved; ; p = filepath.Dir(p) {
+		ancestors = append(ancestors, p)
+		if filepath.Dir(p) == p {
+			break
+		}
+	}
+	for i := len(ancestors) - 1; i >= 0; i-- {
+		p := ancestors[i]
+		info, err := os.Lstat(p)
+		if err != nil {
+			return "", err
+		}
+		wantDir := i != 0 || directory
+		if (wantDir && !info.IsDir()) || (!wantDir && !info.Mode().IsRegular()) {
+			return "", fmt.Errorf("native path has unexpected file type: %s", p)
+		}
+		libraryDirectory := wantDir && ((directory && i == 0) || (!directory && i == 1))
+		if err := checkNativePathPermissions(p, info, libraryDirectory); err != nil {
+			return "", err
+		}
+	}
+	return resolved, nil
+}

--- a/internal/native/library_trust_other.go
+++ b/internal/native/library_trust_other.go
@@ -1,0 +1,12 @@
+//go:build cgo && !unix && !windows
+
+package native
+
+import (
+	"fmt"
+	"os"
+)
+
+func checkNativePathPermissions(path string, _ os.FileInfo, _ bool) error {
+	return fmt.Errorf("native path permission checks are unsupported on this platform: %s", path)
+}

--- a/internal/native/library_trust_unix.go
+++ b/internal/native/library_trust_unix.go
@@ -1,0 +1,26 @@
+//go:build cgo && unix
+
+package native
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func checkNativePathPermissions(path string, info os.FileInfo, libraryDirectory bool) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("could not inspect ownership of %s", path)
+	}
+	if uid := stat.Uid; uid != uint32(os.Geteuid()) && uid != 0 {
+		return fmt.Errorf("native path is owned by another user: %s (uid %d)", path, uid)
+	}
+	// Root-owned sticky ancestors protect existing children from replacement.
+	// The library's own directory must also prevent new dependency files.
+	stickyRoot := !libraryDirectory && info.IsDir() && stat.Uid == 0 && info.Mode()&os.ModeSticky != 0
+	if info.Mode().Perm()&0o022 != 0 && !stickyRoot {
+		return fmt.Errorf("native path is writable by other users: %s (mode %04o)", path, info.Mode().Perm())
+	}
+	return checkNativeACLPermissions(path, info.IsDir(), libraryDirectory)
+}

--- a/internal/native/library_trust_unix_test.go
+++ b/internal/native/library_trust_unix_test.go
@@ -1,0 +1,75 @@
+//go:build cgo && unix
+
+package native
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNativePathRejectsWritableAncestorsAndFiles(t *testing.T) {
+	for _, target := range []string{"parent", "file"} {
+		t.Run(target, func(t *testing.T) {
+			parent := filepath.Join(t.TempDir(), "cache")
+			dir := filepath.Join(parent, "version")
+			if err := os.MkdirAll(dir, 0700); err != nil {
+				t.Fatal(err)
+			}
+			file := filepath.Join(dir, "native")
+			if err := os.WriteFile(file, []byte("library"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := trustedNativePath(file, false); err != nil {
+				t.Fatal(err)
+			}
+			path := parent
+			if target == "file" {
+				path = file
+			}
+			if err := os.Chmod(path, 0777); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := trustedNativePath(file, false); err == nil || !strings.Contains(err.Error(), "writable") {
+				t.Fatalf("accepted writable %s: %v", target, err)
+			}
+		})
+	}
+}
+
+func TestNativePathUsesResolvedSymlinkTarget(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "native")
+	link := filepath.Join(root, "link")
+	if err := os.WriteFile(target, []byte("verified library"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := trustedNativePath(link, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(link, []byte("replacement"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(resolved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "verified library" {
+		t.Fatalf("redirected resolved load path: %q", got)
+	}
+}
+
+func TestNativePathRejectsSpecialFiles(t *testing.T) {
+	// A directory where the library should be must fail before opening/hashing.
+	if _, err := trustedNativePath(t.TempDir(), false); err == nil {
+		t.Fatal("accepted a directory as a native library")
+	}
+}

--- a/internal/native/library_trust_windows.go
+++ b/internal/native/library_trust_windows.go
@@ -1,0 +1,84 @@
+//go:build cgo && windows
+
+package native
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func checkNativePathPermissions(path string, info os.FileInfo, libraryDirectory bool) error {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return err
+	}
+	sd, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT,
+		windows.OWNER_SECURITY_INFORMATION|windows.DACL_SECURITY_INFORMATION)
+	if err != nil {
+		return fmt.Errorf("could not inspect native path %s: %w", path, err)
+	}
+	// TrustedInstaller can own the volume root and system directories.
+	trustedInstaller, _, _, err := windows.LookupSID("", `NT SERVICE\TrustedInstaller`)
+	if err != nil {
+		return fmt.Errorf("could not resolve TrustedInstaller: %w", err)
+	}
+	// Owner and ACE SIDs point into sd's storage.
+	defer runtime.KeepAlive(sd)
+	trustedSID := func(sid *windows.SID) bool {
+		return sid != nil && (sid.Equals(user.User.Sid) || sid.Equals(trustedInstaller) ||
+			sid.IsWellKnown(windows.WinLocalSystemSid) ||
+			sid.IsWellKnown(windows.WinBuiltinAdministratorsSid))
+	}
+	owner, _, err := sd.Owner()
+	if err != nil {
+		return err
+	}
+	if !trustedSID(owner) {
+		return fmt.Errorf("native path is owned by another user: %s", path)
+	}
+	acl, _, err := sd.DACL()
+	if err != nil {
+		return err
+	}
+	if acl == nil {
+		return fmt.Errorf("native path has no restrictive DACL: %s", path)
+	}
+	// DELETE_CHILD bypasses a child's DACL. Allow creation only in ancestors;
+	// the library directory must prevent planted dependencies.
+	const deleteChild windows.ACCESS_MASK = 0x40
+	writes := windows.ACCESS_MASK(windows.DELETE | windows.WRITE_DAC | windows.WRITE_OWNER | windows.GENERIC_WRITE | windows.GENERIC_ALL)
+	if info.IsDir() {
+		writes |= deleteChild
+		if libraryDirectory {
+			writes |= windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA
+		}
+	} else {
+		writes |= windows.FILE_WRITE_DATA | windows.FILE_APPEND_DATA
+	}
+	for i := uint32(0); i < uint32(acl.AceCount); i++ {
+		var ace *windows.ACCESS_ALLOWED_ACE
+		if err := windows.GetAce(acl, i, &ace); err != nil {
+			return err
+		}
+		if ace.Header.AceFlags&windows.INHERIT_ONLY_ACE != 0 {
+			continue
+		}
+		switch ace.Header.AceType {
+		case windows.ACCESS_DENIED_ACE_TYPE:
+			// Ignoring denies is conservative: an ambiguous ACL is rejected.
+			continue
+		case windows.ACCESS_ALLOWED_ACE_TYPE:
+			sid := (*windows.SID)(unsafe.Pointer(&ace.SidStart))
+			if ace.Mask&writes != 0 && !trustedSID(sid) {
+				return fmt.Errorf("native path is writable by other users: %s", path)
+			}
+		default:
+			return fmt.Errorf("native path has an unsupported ACL entry: %s", path)
+		}
+	}
+	return nil
+}

--- a/internal/native/library_trust_windows_test.go
+++ b/internal/native/library_trust_windows_test.go
@@ -1,0 +1,66 @@
+//go:build cgo && windows
+
+package native
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestNativePathRejectsWritableWindowsACL(t *testing.T) {
+	for _, target := range []string{"parent", "file"} {
+		t.Run(target, func(t *testing.T) {
+			parent := filepath.Join(t.TempDir(), "cache")
+			dir := filepath.Join(parent, "version")
+			if err := os.MkdirAll(dir, 0700); err != nil {
+				t.Fatal(err)
+			}
+			file := filepath.Join(dir, "native")
+			if err := os.WriteFile(file, []byte("library"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := trustedNativePath(file, false); err != nil {
+				t.Fatal(err)
+			}
+			path := parent
+			if target == "file" {
+				path = file
+			}
+			original, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
+			if err != nil {
+				t.Fatal(err)
+			}
+			originalACL, _, err := original.DACL()
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION, nil, nil, originalACL, nil); err != nil {
+					t.Error(err)
+				}
+			})
+			user, err := windows.GetCurrentProcessToken().GetTokenUser()
+			if err != nil {
+				t.Fatal(err)
+			}
+			sd, err := windows.SecurityDescriptorFromString("D:P(A;;FA;;;" + user.User.Sid.String() + ")(A;;FA;;;WD)")
+			if err != nil {
+				t.Fatal(err)
+			}
+			acl, _, err := sd.DACL()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, acl, nil); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := trustedNativePath(file, false); err == nil || !strings.Contains(err.Error(), "writable") {
+				t.Fatalf("accepted writable %s: %v", target, err)
+			}
+		})
+	}
+}

--- a/internal/native/library_trust_windows_test.go
+++ b/internal/native/library_trust_windows_test.go
@@ -3,6 +3,7 @@
 package native
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,56 +12,71 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func TestNativePathRejectsWritableWindowsACL(t *testing.T) {
-	for _, target := range []string{"parent", "file"} {
-		t.Run(target, func(t *testing.T) {
-			parent := filepath.Join(t.TempDir(), "cache")
-			dir := filepath.Join(parent, "version")
-			if err := os.MkdirAll(dir, 0700); err != nil {
-				t.Fatal(err)
+func TestNativePathPermissionsRejectWritableWindowsACL(t *testing.T) {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateDACL := "D:P(A;;FA;;;" + user.User.Sid.String() + ")"
+	for _, tc := range []struct {
+		name             string
+		file             bool
+		libraryDirectory bool
+		mask             windows.ACCESS_MASK
+		wantRejected     bool
+	}{
+		{name: "ancestor_delete_child", mask: 0x40, wantRejected: true},
+		{name: "ancestor_create_file", mask: windows.FILE_WRITE_DATA},
+		{name: "library_directory_create_file", libraryDirectory: true, mask: windows.FILE_WRITE_DATA, wantRejected: true},
+		{name: "file_write", file: true, mask: windows.FILE_WRITE_DATA, wantRejected: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "native")
+			var err error
+			if tc.file {
+				err = os.WriteFile(path, []byte("library"), 0600)
+			} else {
+				err = os.Mkdir(path, 0700)
 			}
-			file := filepath.Join(dir, "native")
-			if err := os.WriteFile(file, []byte("library"), 0600); err != nil {
-				t.Fatal(err)
-			}
-			if _, err := trustedNativePath(file, false); err != nil {
-				t.Fatal(err)
-			}
-			path := parent
-			if target == "file" {
-				path = file
-			}
-			original, err := windows.GetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION)
 			if err != nil {
 				t.Fatal(err)
 			}
-			originalACL, _, err := original.DACL()
+			info, err := os.Stat(path)
 			if err != nil {
 				t.Fatal(err)
 			}
-			t.Cleanup(func() {
-				if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION, nil, nil, originalACL, nil); err != nil {
-					t.Error(err)
+			// Control this path's DACL without assuming its host ancestors are trusted.
+			setNativeTestDACL(t, path, privateDACL)
+			t.Cleanup(func() { setNativeTestDACL(t, path, privateDACL) })
+			if err := checkNativePathPermissions(path, info, tc.libraryDirectory); err != nil {
+				t.Fatal(err)
+			}
+			setNativeTestDACL(t, path, privateDACL+fmt.Sprintf("(A;;0x%08x;;;WD)", tc.mask))
+			err = checkNativePathPermissions(path, info, tc.libraryDirectory)
+			if tc.wantRejected {
+				if err == nil || !strings.Contains(err.Error(), "writable") {
+					t.Fatalf("accepted unsafe ACL: %v", err)
 				}
-			})
-			user, err := windows.GetCurrentProcessToken().GetTokenUser()
-			if err != nil {
-				t.Fatal(err)
-			}
-			sd, err := windows.SecurityDescriptorFromString("D:P(A;;FA;;;" + user.User.Sid.String() + ")(A;;FA;;;WD)")
-			if err != nil {
-				t.Fatal(err)
-			}
-			acl, _, err := sd.DACL()
-			if err != nil {
-				t.Fatal(err)
-			}
-			if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, acl, nil); err != nil {
-				t.Fatal(err)
-			}
-			if _, err := trustedNativePath(file, false); err == nil || !strings.Contains(err.Error(), "writable") {
-				t.Fatalf("accepted writable %s: %v", target, err)
+			} else if err != nil {
+				t.Fatalf("rejected safe ancestor permissions: %v", err)
 			}
 		})
+	}
+}
+
+func setNativeTestDACL(t *testing.T, path, sddl string) {
+	t.Helper()
+	sd, err := windows.SecurityDescriptorFromString(sddl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	acl, _, err := sd.DACL()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := windows.SetNamedSecurityInfo(path, windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil, nil, acl, nil); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/native/native.go
+++ b/internal/native/native.go
@@ -85,6 +85,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"strings"
 	"sync"
 	"unsafe"
 
@@ -95,6 +96,14 @@ import (
 )
 
 const stateOK = 0
+
+// Reject NULs before native C-string consumers silently truncate the value.
+func checkNoNULByte(value, what string) error {
+	if strings.IndexByte(value, 0) >= 0 {
+		return fmt.Errorf("datafusion-go %s contains a NUL byte", what)
+	}
+	return nil
+}
 
 type Error struct {
 	Kind    string
@@ -149,6 +158,9 @@ type resultReader struct {
 }
 
 func OpenDatabase(dsn string) (*Database, error) {
+	if err := checkNoNULByte(dsn, "DSN"); err != nil {
+		return nil, err
+	}
 	if err := ensureNativeLibraryLoaded(); err != nil {
 		return nil, err
 	}
@@ -252,6 +264,9 @@ func (conn *Connection) RegisterArrowIPC(name string, data []byte) error {
 	if conn == nil || conn.ptr == nil {
 		return errors.New("datafusion-go connection is closed")
 	}
+	if err := checkNoNULByte(name, "table name"); err != nil {
+		return err
+	}
 
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
@@ -283,6 +298,12 @@ func (conn *Connection) RegisterFFITableProvider(name string, provider unsafe.Po
 	if provider == nil {
 		return errors.New("datafusion-go FFI table provider is nil")
 	}
+	if err := checkNoNULByte(name, "table name"); err != nil {
+		return err
+	}
+	if err := checkNoNULByte(providerDataFusionVersion, "provider datafusion version"); err != nil {
+		return err
+	}
 
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
@@ -302,6 +323,9 @@ func (conn *Connection) DeregisterTable(name string) error {
 	if conn == nil || conn.ptr == nil {
 		return errors.New("datafusion-go connection is closed")
 	}
+	if err := checkNoNULByte(name, "table name"); err != nil {
+		return err
+	}
 
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
@@ -320,6 +344,9 @@ func (conn *Connection) RegisterArrowReaderZeroCopy(name string, reader array.Re
 	if reader == nil {
 		return errors.New("datafusion-go arrow reader is nil")
 	}
+	if err := checkNoNULByte(name, "table name"); err != nil {
+		return err
+	}
 
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
@@ -328,14 +355,18 @@ func (conn *Connection) RegisterArrowReaderZeroCopy(name string, reader array.Re
 	if stream == nil {
 		return errors.New("datafusion-go could not allocate Arrow stream")
 	}
-	cdata.ExportRecordReader(reader, (*cdata.CArrowArrayStream)(unsafe.Pointer(stream)))
+	// Rust consumes the callbacks; this wrapper owns the stream allocation.
+	defer C.free(unsafe.Pointer(stream))
+	// Keep caller callbacks behind an error boundary while Rust drains the
+	// reader synchronously, so a Go panic cannot skip Rust destructors.
+	safeReader, err := newPanicSafeRecordReader(reader)
+	if err != nil {
+		return err
+	}
+	cdata.ExportRecordReader(safeReader, (*cdata.CArrowArrayStream)(unsafe.Pointer(stream)))
 
 	var cerr *C.dfgo_error
-	errno := C.dfgo_connection_register_arrow_stream(conn.ptr, cname, stream, &cerr)
-	// Rust moves the stream callbacks out of this allocation and owns their
-	// release path. The allocation itself still belongs to this cgo wrapper.
-	C.free(unsafe.Pointer(stream))
-	if errno != stateOK {
+	if C.dfgo_connection_register_arrow_stream(conn.ptr, cname, stream, &cerr) != stateOK {
 		return takeError(cerr)
 	}
 	return nil
@@ -344,6 +375,9 @@ func (conn *Connection) RegisterArrowReaderZeroCopy(name string, reader array.Re
 func (conn *Connection) Prepare(query string) (*Statement, error) {
 	if conn == nil || conn.ptr == nil {
 		return nil, errors.New("datafusion-go connection is closed")
+	}
+	if err := checkNoNULByte(query, "query"); err != nil {
+		return nil, err
 	}
 
 	cquery := C.CString(query)
@@ -484,6 +518,11 @@ func statementParams(args []driver.NamedValue) ([]C.dfgo_parameter, func(), erro
 		if ordinal <= 0 {
 			cleanup()
 			return nil, nil, fmt.Errorf("parameter ordinal must be positive, got %d", ordinal)
+		}
+		// Bound native binding allocations, which are sized by ordinal.
+		if ordinal > len(args) {
+			cleanup()
+			return nil, nil, fmt.Errorf("parameter ordinal %d exceeds the number of arguments %d", ordinal, len(args))
 		}
 
 		param := &params[i]

--- a/internal/native/record_reader.go
+++ b/internal/native/record_reader.go
@@ -1,0 +1,74 @@
+//go:build cgo
+
+package native
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+)
+
+// panicSafeRecordReader catches producer panics before Arrow exports a batch
+// or error. Next fetches both inside its recovery boundary.
+//
+// Registration borrows inner synchronously; the caller owns its reference.
+// Retain/Release are no-ops to keep producer cleanup out of Rust callbacks.
+// Exported batches retain their own buffers.
+type panicSafeRecordReader struct {
+	inner  array.RecordReader
+	schema *arrow.Schema
+	record arrow.RecordBatch
+	err    error
+	done   bool
+}
+
+func newPanicSafeRecordReader(inner array.RecordReader) (r *panicSafeRecordReader, err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			err = fmt.Errorf("datafusion-go arrow reader Schema panicked: %v", p)
+		}
+	}()
+	schema := inner.Schema()
+	if schema == nil {
+		return nil, errors.New("datafusion-go arrow reader schema is nil")
+	}
+	return &panicSafeRecordReader{inner: inner, schema: schema}, nil
+}
+
+func (r *panicSafeRecordReader) Next() (ok bool) {
+	r.record = nil
+	if r.done {
+		return false
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			r.err = fmt.Errorf("datafusion-go arrow reader callback panicked: %v", p)
+			r.done = true
+		}
+	}()
+	if !r.inner.Next() {
+		r.done = true
+		if err := r.inner.Err(); err != nil {
+			r.err = errors.New(err.Error())
+		}
+		return false
+	}
+	r.record = r.inner.RecordBatch()
+	if r.record == nil {
+		r.err = errors.New("datafusion-go arrow reader returned a nil batch after Next")
+		r.done = true
+		return false
+	}
+	return true
+}
+
+func (r *panicSafeRecordReader) RecordBatch() arrow.RecordBatch { return r.record }
+func (r *panicSafeRecordReader) Record() arrow.RecordBatch      { return r.record }
+func (r *panicSafeRecordReader) Schema() *arrow.Schema          { return r.schema }
+func (r *panicSafeRecordReader) Err() error                     { return r.err }
+func (r *panicSafeRecordReader) Retain()                        {}
+func (r *panicSafeRecordReader) Release()                       {}
+
+var _ array.RecordReader = (*panicSafeRecordReader)(nil)

--- a/internal/native/secure_execution.go
+++ b/internal/native/secure_execution.go
@@ -1,0 +1,14 @@
+//go:build cgo
+
+package native
+
+import "os"
+
+// secureExecution detects privileges gained through setuid, setgid, or file
+// capabilities; runtime library loading is disabled in this state.
+func secureExecution() bool {
+	if os.Geteuid() != os.Getuid() || os.Getegid() != os.Getgid() {
+		return true
+	}
+	return secureExecutionPlatform()
+}

--- a/internal/native/secure_execution_darwin.go
+++ b/internal/native/secure_execution_darwin.go
@@ -1,0 +1,14 @@
+//go:build cgo && darwin
+
+package native
+
+/*
+#include <unistd.h>
+*/
+import "C"
+
+func secureExecutionPlatform() bool {
+	// issetugid stays true for the process lifetime once the exec was tainted,
+	// even after the effective IDs are reset to the real IDs.
+	return C.issetugid() != 0
+}

--- a/internal/native/secure_execution_linux.go
+++ b/internal/native/secure_execution_linux.go
@@ -1,0 +1,21 @@
+//go:build cgo && linux
+
+package native
+
+/*
+#include <errno.h>
+#include <sys/auxv.h>
+
+static int dfgo_secure_execution(void) {
+    errno = 0;
+    unsigned long secure = getauxval(AT_SECURE);
+    // The libc auxiliary vector survives chroot and does not require /proc.
+    // If the flag cannot be read, refuse runtime loading.
+    return secure != 0 || errno != 0;
+}
+*/
+import "C"
+
+func secureExecutionPlatform() bool {
+	return C.dfgo_secure_execution() != 0
+}

--- a/internal/native/secure_execution_linux_test.go
+++ b/internal/native/secure_execution_linux_test.go
@@ -1,0 +1,93 @@
+//go:build cgo && linux
+
+package native
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// Requires a disposable root container with setcap; see CONTRIBUTING.md.
+func TestSecureExecutionWithCapabilitiesWithoutProc(t *testing.T) {
+	const childEnv = "DFGO_TEST_CAPABILITY_CHROOT"
+	if root := os.Getenv(childEnv); root != "" {
+		if os.Getuid() == 0 || os.Getuid() != os.Geteuid() {
+			t.Fatal("fixture must run with equal non-root IDs")
+		}
+		if err := syscall.Chroot(root); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir("/"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat("/proc/self/auxv"); !os.IsNotExist(err) {
+			t.Fatalf("expected absent /proc: %v", err)
+		}
+		if !secureExecution() {
+			t.Fatal("lost AT_SECURE after chroot")
+		}
+		if _, err := resolveNativeLibrary(); err == nil || !strings.Contains(err.Error(), "privileged") {
+			t.Fatalf("privileged resolution: %v", err)
+		}
+		return
+	}
+	if os.Geteuid() != 0 {
+		t.Skip("requires root in a disposable container")
+	}
+	setcap, err := exec.LookPath("setcap")
+	if err != nil {
+		t.Skip("setcap is unavailable")
+	}
+	root, err := os.MkdirTemp("", "dfgo-capability-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(root); err != nil {
+			t.Error(err)
+		}
+	})
+	if err := os.Chmod(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+	empty := filepath.Join(root, "empty")
+	if err := os.Mkdir(empty, 0755); err != nil {
+		t.Fatal(err)
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := os.Open(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = source.Close() }()
+	target := filepath.Join(root, "test")
+	dst, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, copyErr := io.Copy(dst, source)
+	closeErr := dst.Close()
+	if copyErr != nil {
+		t.Fatal(copyErr)
+	}
+	if closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	if out, err := exec.Command(setcap, "cap_sys_chroot=ep", target).CombinedOutput(); err != nil {
+		t.Fatalf("setcap: %v: %s", err, out)
+	}
+	child := exec.Command(target, "-test.run=^TestSecureExecutionWithCapabilitiesWithoutProc$", "-test.v")
+	child.Env = append(os.Environ(), childEnv+"="+empty)
+	child.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: 65534, Gid: 65534}}
+	if out, err := child.CombinedOutput(); err != nil {
+		t.Fatalf("capability subprocess: %v: %s", err, out)
+	}
+}

--- a/internal/native/secure_execution_other.go
+++ b/internal/native/secure_execution_other.go
@@ -1,0 +1,7 @@
+//go:build cgo && !linux && !darwin
+
+package native
+
+func secureExecutionPlatform() bool {
+	return false
+}

--- a/internal/native/security_test.go
+++ b/internal/native/security_test.go
@@ -1,0 +1,161 @@
+//go:build cgo
+
+package native
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestResolveNativeLibraryRejectsRelativeEnvPath(t *testing.T) {
+	t.Setenv(nativeLibraryEnv, "relative/libdatafusion_go.so")
+	_, err := resolveNativeLibrary()
+	if err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("expected absolute-path error, got %v", err)
+	}
+}
+
+func TestNativeDownloadURLRejectsNonHTTPSBase(t *testing.T) {
+	for _, base := range []string{"http://example.com/assets", "ftp://example.com", "example.com/assets", "https://"} {
+		t.Setenv(nativeDownloadBaseEnv, base)
+		if _, err := nativeDownloadURL("asset"); err == nil {
+			t.Errorf("expected error for download base %q", base)
+		}
+	}
+}
+
+func TestNativeDownloadURLAcceptsDefaultAndHTTPSBase(t *testing.T) {
+	t.Setenv(nativeDownloadBaseEnv, "")
+	url, err := nativeDownloadURL("asset")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(url, "https://github.com/datafusion-contrib/datafusion-go/releases/download/") {
+		t.Fatalf("unexpected default download URL %q", url)
+	}
+
+	t.Setenv(nativeDownloadBaseEnv, "https://mirror.example.com/datafusion/")
+	url, err = nativeDownloadURL("asset")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if url != "https://mirror.example.com/datafusion/asset" {
+		t.Fatalf("unexpected mirrored download URL %q", url)
+	}
+}
+
+func TestNULBytesAreRejectedAtTheFFIBoundary(t *testing.T) {
+	if _, err := OpenDatabase("\x00?x=y"); err == nil || !strings.Contains(err.Error(), "NUL") {
+		t.Errorf("DSN with NUL byte: got %v, want NUL rejection", err)
+	}
+
+	db, err := OpenDatabase("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	conn, err := db.Connect(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Prepare("select 1 \x00 -- dropped"); err == nil || !strings.Contains(err.Error(), "NUL") {
+		t.Errorf("query with NUL byte: got %v, want NUL rejection", err)
+	}
+	if err := conn.RegisterArrowIPC("tenant_alice\x00-me", nil); err == nil || !strings.Contains(err.Error(), "NUL") {
+		t.Errorf("RegisterArrowIPC name with NUL byte: got %v, want NUL rejection", err)
+	}
+	if err := conn.DeregisterTable("tenant_alice\x00-me"); err == nil || !strings.Contains(err.Error(), "NUL") {
+		t.Errorf("DeregisterTable name with NUL byte: got %v, want NUL rejection", err)
+	}
+}
+
+func TestOversizedParameterOrdinalIsRejected(t *testing.T) {
+	db, err := OpenDatabase("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	conn, err := db.Connect(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	stmt, err := conn.Prepare("select $1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+
+	_, err = stmt.ExecuteArrow(context.Background(), []driver.NamedValue{{
+		Ordinal: 1 << 40,
+		Value:   int64(1),
+	}})
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("oversized ordinal: got %v, want ordinal-bound rejection", err)
+	}
+}
+
+func TestPrivilegedResolutionRejectsAllRuntimePaths(t *testing.T) {
+	t.Setenv(nativeLibraryEnv, filepath.Join(t.TempDir(), "native-library"))
+	t.Setenv(nativeDownloadBaseEnv, "https://example.com")
+	if _, err := resolveNativeLibraryForExecution(true); err == nil || !strings.Contains(err.Error(), "privileged") {
+		t.Fatalf("expected privileged execution error before path resolution, got %v", err)
+	}
+}
+
+func TestDownloadRejectsHTTPRedirect(t *testing.T) {
+	var received atomic.Bool
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer destination.Close()
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL, http.StatusFound)
+	}))
+	defer redirect.Close()
+	dst, err := os.CreateTemp(t.TempDir(), "download")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = dst.Close() }()
+	if err := downloadFile(dst, redirect.URL); err == nil || !strings.Contains(err.Error(), "HTTPS") {
+		t.Fatalf("expected HTTPS redirect rejection, got %v", err)
+	}
+	if received.Load() {
+		t.Fatal("followed insecure redirect")
+	}
+}
+
+func TestDownloadRejectsOversizedContentLength(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprint(maxNativeAssetSize+1))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	dst, err := os.CreateTemp(t.TempDir(), "download")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = dst.Close() }()
+	if err := downloadFile(dst, server.URL); err == nil || !strings.Contains(err.Error(), "limit") {
+		t.Fatalf("expected size limit rejection, got %v", err)
+	}
+	info, err := dst.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() != 0 {
+		t.Fatal("oversized download wrote bytes")
+	}
+}

--- a/internal/native/version_generated.go
+++ b/internal/native/version_generated.go
@@ -5,4 +5,4 @@ package native
 
 const abiVersion = 1
 const dataFusionVersion = "55.0.0"
-const dataFusionGoVersion = "0.550000.0"
+const dataFusionGoVersion = "0.550000.1"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-go"
-version = "0.550000.0"
+version = "0.550000.1"
 dependencies = [
  "datafusion",
  "datafusion-ffi",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datafusion-go"
-version = "0.550000.0"
+version = "0.550000.1"
 edition = "2024"
 rust-version = "1.94"
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -356,7 +356,11 @@ impl Iterator for StreamingReader {
             Some(Ok(batch)) => Some(Ok(batch)),
             Some(Err(err)) => {
                 self.done = true;
-                Some(Err(ArrowError::ExternalError(Box::new(err))))
+                Some(Err(ArrowError::ExternalError(Box::new(
+                    // Arrow's C callback puts this text in a CString and
+                    // aborts on interior NULs, including values in cast errors.
+                    std::io::Error::other(err.to_string().replace('\0', "\\0")),
+                ))))
             }
             None => {
                 self.done = true;
@@ -899,6 +903,14 @@ fn bindings_from_params(
 
         let index = usize::try_from(param.index - 1)
             .map_err(|e| FfiError::invalid_argument(e.to_string()))?;
+        // Dense bindings need at most params_len slots. Bound the allocation
+        // before resize_with uses the caller's index.
+        if index >= params_len {
+            return Err(FfiError::invalid_argument(format!(
+                "parameter index {} exceeds parameters length {params_len}",
+                param.index
+            )));
+        }
         if bindings.len() <= index {
             bindings.resize_with(index + 1, || Binding {
                 name: None,
@@ -2272,6 +2284,32 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn rejects_parameter_index_beyond_parameters_length() {
+        let param = dfgo_parameter {
+            index: i64::MAX,
+            name: ptr::null(),
+            name_len: 0,
+            type_code: PARAMETER_INT64,
+            is_null: 0,
+            int64_value: 7,
+            uint64_value: 0,
+            float64_value: 0.0,
+            data: ptr::null(),
+            data_len: 0,
+            timezone: ptr::null(),
+            timezone_len: 0,
+            precision: 0,
+            scale: 0,
+        };
+        let err = match bindings_from_params(&param, 1) {
+            Err(err) => err,
+            Ok(_) => panic!("expected an error for an oversized parameter index"),
+        };
+        assert_eq!(err.kind, ERROR_KIND_INVALID_ARGUMENT);
+        assert!(err.message.contains("exceeds"), "{}", err.message);
     }
 
     #[test]

--- a/security_test.go
+++ b/security_test.go
@@ -1,0 +1,258 @@
+//go:build cgo
+
+package datafusion
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/arrow/memory/mallocator"
+)
+
+func TestQueryWithNULByteIsRejected(t *testing.T) {
+	db, err := sql.Open("datafusion", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeNoError(t, db)
+
+	_, err = db.QueryContext(context.Background(), "select 1 \x00 and dropped_predicate")
+	if err == nil || !strings.Contains(err.Error(), "NUL") {
+		t.Fatalf("query with NUL byte: got %v, want NUL rejection", err)
+	}
+}
+
+type callbackFailureReader struct {
+	array.RecordReader
+	fault     string
+	nextCalls int
+}
+
+func (r *callbackFailureReader) Schema() *arrow.Schema {
+	// Public validation calls Schema once before entering the native wrapper.
+	if r.fault == "Schema" && r.nextCalls == -1 {
+		panic("Schema failure")
+	}
+	if r.fault == "Schema" {
+		r.nextCalls = -1
+	}
+	return r.RecordReader.Schema()
+}
+func (r *callbackFailureReader) Next() bool {
+	r.nextCalls++
+	if r.nextCalls == 1 {
+		return r.RecordReader.Next()
+	}
+	if r.fault == "Next" {
+		panic("Next failure")
+	}
+	return r.fault == "RecordBatch" || r.fault == "nil batch"
+}
+func (r *callbackFailureReader) RecordBatch() arrow.RecordBatch {
+	if r.nextCalls > 1 {
+		if r.fault == "RecordBatch" {
+			panic("RecordBatch failure")
+		}
+		if r.fault == "nil batch" {
+			return nil
+		}
+	}
+	return r.RecordReader.RecordBatch()
+}
+func (r *callbackFailureReader) Err() error {
+	switch r.fault {
+	case "Err":
+		panic("Err failure")
+	case "Error":
+		return callbackFailureError{}
+	case "ordinary error":
+		return errors.New("ordinary error")
+	}
+	return nil
+}
+
+// Registration borrows the reader; neither callback should run from Rust.
+func (r *callbackFailureReader) Retain()  { panic("unexpected Retain") }
+func (r *callbackFailureReader) Release() { panic("unexpected Release") }
+
+type callbackFailureError struct{}
+
+func (callbackFailureError) Error() string { panic("Error failure") }
+
+func TestZeroCopyCallbackFailuresReleaseBuffers(t *testing.T) {
+	for _, fault := range []string{"Schema", "Next", "RecordBatch", "nil batch", "Err", "Error", "ordinary error", "success"} {
+		t.Run(fault, func(t *testing.T) {
+			alloc := memory.NewCheckedAllocator(mallocator.NewMallocator())
+			defer alloc.AssertSize(t, 0)
+			conn := openTestConn(t)
+			inner := nativeTableReader(t, alloc)
+			reader := &callbackFailureReader{RecordReader: inner, fault: fault}
+			err := RegisterArrowReaderZeroCopy(context.Background(), conn, "callback_table", reader)
+			inner.Release()
+			if fault == "success" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				var total int
+				if err := conn.QueryRowContext(context.Background(), "select sum(value) from callback_table").Scan(&total); err != nil {
+					t.Fatal(err)
+				}
+				if total != 6 {
+					t.Fatalf("sum %d, want 6", total)
+				}
+				if _, err := conn.ExecContext(context.Background(), "drop table callback_table"); err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), fault) {
+				t.Fatalf("got %v, want %s failure", err, fault)
+			}
+			alloc.AssertSize(t, 0)
+		})
+	}
+}
+
+func TestNativeStreamSanitizesNULInExecutionError(t *testing.T) {
+	conn := openTestConn(t)
+	reader, err := QueryArrowContext(context.Background(), conn,
+		"select cast(concat(cast(value as varchar), $1) as bigint) from range(3)", "a\x00b")
+	if err != nil {
+		t.Fatalf("expected an error during Read, got %v", err)
+	}
+	defer closeNoError(t, reader)
+	batch, err := reader.Read()
+	if batch != nil {
+		batch.Release()
+	}
+	if err == nil || !strings.Contains(err.Error(), "a\\0b") || strings.ContainsRune(err.Error(), 0) {
+		t.Fatalf("expected a sanitized stream error, got %v", err)
+	}
+}
+
+type gcBlockingReader struct {
+	entered chan struct{}
+	resume  chan struct{}
+	closed  chan struct{}
+	once    sync.Once
+}
+
+func (r *gcBlockingReader) Schema() *arrow.Schema { return arrow.NewSchema(nil, nil) }
+func (r *gcBlockingReader) Read() (arrow.RecordBatch, error) {
+	close(r.entered)
+	<-r.resume
+	return nil, io.EOF
+}
+func (r *gcBlockingReader) Close() error { r.once.Do(func() { close(r.closed) }); return nil }
+
+func TestSerializedReaderStaysAliveDuringRead(t *testing.T) {
+	inner := &gcBlockingReader{entered: make(chan struct{}), resume: make(chan struct{}), closed: make(chan struct{})}
+	done := make(chan error, 1)
+	go func() {
+		// No retained wrapper reference after this call except its receiver.
+		_, err := newSerializedArrowReader(inner, func() {}).Read()
+		done <- err
+	}()
+	<-inner.entered
+	for range 8 {
+		runtime.GC()
+		runtime.Gosched()
+	}
+	select {
+	case <-inner.closed:
+		t.Error("finalizer closed a reader during Read")
+	default:
+	}
+	close(inner.resume)
+	select {
+	case err := <-done:
+		if err != io.EOF {
+			t.Fatalf("Read got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Read did not finish")
+	}
+}
+
+func TestQueryArrowConcurrentCloseAndReset(t *testing.T) {
+	for _, action := range []string{"close", "reset"} {
+		t.Run(action, func(t *testing.T) {
+			connector, err := NewConnectorWithInitContext("", nil, WithSharedSession(false))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer closeNoError(t, connector)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			driverConn, err := connector.Connect(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			conn := driverConn.(*Conn)
+			defer closeNoError(t, conn)
+			start := make(chan struct{})
+			errs := make(chan error, 5)
+			var workers sync.WaitGroup
+			for range 4 {
+				workers.Go(func() {
+					<-start
+					for range 64 {
+						reader, err := conn.QueryArrowContext(ctx, "select 1", []driver.NamedValue{})
+						if err != nil {
+							var de *Error
+							if action == "close" && errors.As(err, &de) && de.Type == ErrorClosed {
+								return
+							}
+							errs <- err
+							return
+						}
+						rec, err := reader.Read()
+						if rec != nil {
+							rec.Release()
+						}
+						closeErr := reader.Close()
+						if err != nil {
+							errs <- err
+							return
+						}
+						if closeErr != nil {
+							errs <- closeErr
+							return
+						}
+					}
+				})
+			}
+			workers.Go(func() {
+				<-start
+				for range 64 {
+					var err error
+					if action == "close" {
+						err = conn.Close()
+					} else {
+						err = conn.ResetSession(ctx)
+					}
+					if err != nil {
+						errs <- err
+						return
+					}
+					runtime.Gosched()
+				}
+			})
+			close(start)
+			workers.Wait()
+			close(errs)
+			for err := range errs {
+				t.Error(err)
+			}
+		})
+	}
+}

--- a/version.go
+++ b/version.go
@@ -13,8 +13,8 @@ const (
 	DataFusionGoMajor = 0
 
 	// DataFusionGoPatch is the patch component of datafusion-go release tags.
-	DataFusionGoPatch = 0
+	DataFusionGoPatch = 1
 
 	// DataFusionGoVersion is the full datafusion-go module version without the leading v.
-	DataFusionGoVersion = "0.550000.0"
+	DataFusionGoVersion = "0.550000.1"
 )

--- a/versions.toml
+++ b/versions.toml
@@ -9,7 +9,7 @@ version = "55.0.0"
 # Release tags are v<major>.<encoded-datafusion-version>.<patch>.
 # DataFusion 53.1.0 with major 0 and patch 1 becomes v0.530100.1.
 major = 0
-patch = 0
+patch = 1
 
 [abi]
 # Increment when the C ABI shared by Rust, C, and Go changes incompatibly.


### PR DESCRIPTION
Arrow reader panics could cross Rust frames and leak imported buffers, while connection close/reset and reader finalization could invalidate native resources during active operations. Contain reader callbacks, retain active wrappers, and protect native connection access with regression coverage for buffer release and concurrent operations.

Runtime library loading now checks canonical paths, ownership, ancestor permissions, and platform ACLs before trusting source or cache libraries. It rejects privileged execution, requires absolute explicit library paths and HTTPS downloads/redirects, bounds asset sizes, and restricts Windows DLL dependency searches.

Also reject embedded NULs at C-string boundaries, sanitize NULs in streamed error messages, and bound parameter ordinals before native allocations. Document the loading restrictions and process-isolation requirements for untrusted workloads. Remove redundant comments while retaining ownership and safety explanations.

Bump the release from `v0.550000.0` to `v0.550000.1` and add the matching changelog entry. DataFusion remains at 55.0.0 and the native ABI remains at 1; version metadata and the Cargo lockfile are regenerated from `versions.toml`.

Validation passed:

- `make generate`, `make generate.check`, and `make changelog.check`.
- `make lint`, `make test`, `make test.source`, `make rust.test` (11 Rust tests).
- `make go.test.race`, `make go.test.nocgo`, `make consumer.smoke`.
- `make go.vuln` and `make rust.audit` reported no known vulnerabilities.
- Linux loader tests on Go 1.25, including the file-capability fixture without `/proc` in a disposable container.
- Windows native-package cross-compilation and `go vet`.
- [All 24 CI checks](https://github.com/datafusion-contrib/datafusion-go/actions/runs/34059020931), including Windows dynamic, bundled, and race tests.

`make release.verify` could not complete locally: the new release artifacts for all five platforms have not been staged. The release workflow performs this verification with the CI artifacts.

