### PR TITLE
chore: prepare v0.550000.2 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to datafusion-go are documented here.
 
+## v0.550000.2 - 2026-09-09
+
+- Consolidated query and statement execution and simplified native ownership and cleanup across Go and Rust.
+- Fixed statement preparation to honor the configured SQL dialect and preserve parameters owned by SQL `PREPARE` and `CREATE FUNCTION` statements, including under `EXPLAIN`.
+- Upgraded Arrow Go to v18.8.0 for correct fractional-hour timezone offsets.
+- Added the pinned DataFusion SQLLogicTest corpus, SQL documentation coverage reports, reproducible datasets, and CI runs on Linux, macOS, and Windows. Replaced platform-dependent trigonometric snapshots with portable assertions. Two zero-length fixed-size-list assertions remain disabled pending Arrow Go support, and parallel spill stress tests run as nonblocking diagnostics.
+- Expanded lifecycle, installation, conformance, fuzzing, and native ABI checks, and clarified setup and usage documentation.
+
 ## v0.550000.1 - 2026-09-06
 
 - Fixed Arrow reader callback panics leaking imported buffers, premature reader finalization during active reads, and native connection access racing with close or session reset.

--- a/internal/native/version_generated.go
+++ b/internal/native/version_generated.go
@@ -5,4 +5,4 @@ package native
 
 const abiVersion = 1
 const dataFusionVersion = "55.0.0"
-const dataFusionGoVersion = "0.550000.1"
+const dataFusionGoVersion = "0.550000.2"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1353,7 +1353,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-go"
-version = "0.550000.1"
+version = "0.550000.2"
 dependencies = [
  "datafusion",
  "datafusion-ffi",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datafusion-go"
-version = "0.550000.1"
+version = "0.550000.2"
 edition = "2024"
 rust-version = "1.94"
 

--- a/version.go
+++ b/version.go
@@ -13,8 +13,8 @@ const (
 	DataFusionGoMajor = 0
 
 	// DataFusionGoPatch is the patch component of datafusion-go release tags.
-	DataFusionGoPatch = 1
+	DataFusionGoPatch = 2
 
 	// DataFusionGoVersion is the full datafusion-go module version without the leading v.
-	DataFusionGoVersion = "0.550000.1"
+	DataFusionGoVersion = "0.550000.2"
 )

--- a/versions.toml
+++ b/versions.toml
@@ -9,7 +9,7 @@ version = "55.0.0"
 # Release tags are v<major>.<encoded-datafusion-version>.<patch>.
 # DataFusion 53.1.0 with major 0 and patch 1 becomes v0.530100.1.
 major = 0
-patch = 1
+patch = 2
 
 [abi]
 # Increment when the C ABI shared by Rust, C, and Go changes incompatibly.


### PR DESCRIPTION
Follow-up to #28: prepare v0.550000.2 so release automation can publish the merged execution and SQL coverage changes instead of skipping the existing v0.550000.1 tag.

Increment `datafusion_go.patch` from 1 to 2 in `versions.toml`, regenerate the Go/Rust version metadata and Cargo lockfile, and add the new changelog entry. DataFusion remains 55.0.0, the module major remains 0, and the native ABI remains 1. This PR contains only the version bump and release notes.

Validation passed on macOS arm64:

- `make generate`, `make generate.check`, and `make changelog.check`
- `make lint`, `make test`, `make test.source`, and `make rust.test`
- `make go.test.race` and `make consumer.smoke`
- `TOKIO_WORKER_THREADS=4 make test.sqllogic`: all 24,956 active assertions passed, with no missing files or documentation gaps

`make release.verify` was attempted but cannot complete with the old local release assets. The matching v0.550000.2 assets for all five platforms must be built and verified by CI and the release workflow.
