### PR TITLE
Require release version bumps for shipped changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          fetch-depth: 0 # Version checks need the base commit and existing release tags.
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -36,6 +37,13 @@ jobs:
 
       - name: Changelog has an entry for the release tag
         run: make changelog.check
+
+      - name: Shipped changes have an appropriate release version
+        env:
+          VERSION_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          : "${VERSION_BASE_REF:?Missing base commit for version check}"
+          go run ./internal/tools/genversions -base-ref "$VERSION_BASE_REF"
 
       - name: No-cgo unsupported path
         run: make go.test.nocgo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,28 @@ It also derives the native loader declarations and ABI contract tests from
 Increment `abi.version` only when the C ABI in `rust/include/datafusion_go.h`
 changes incompatibly with the Go native wrapper.
 
+CI compares each pull request with its base commit, and each push to `main`
+with the previous commit. Changes to shipped Go or Rust code, native headers
+and libraries, dependency manifests, the Makefile, release workflow, or Git
+archive attributes require a version bump and a non-empty changelog entry.
+Documentation, examples, test fixtures, test-only modules, and development
+tooling can keep the existing version. Tests embedded in a production source
+file still count as a change to that file.
+
+For the same DataFusion version, increment `datafusion_go.patch` by one. For
+a newer DataFusion version, reset it to zero. The module major can stay the
+same or increment by one; DataFusion and ABI versions cannot decrease. New
+release tags must not already exist. Generated-file checks also run in CI.
+Two PRs proposing the same next version must update their branches after the
+first merges so their version check runs against the new base.
+
+To run the version check locally after fetching `main` and the release tags:
+
+```sh
+git fetch origin main --tags
+go run ./internal/tools/genversions -base-ref origin/main
+```
+
 ## Native Libraries
 
 The Rust crate under `rust/` builds a static archive and a shared library. The default Go build loads the platform-specific shared library at runtime from `DATAFUSION_GO_LIBRARY`, from `internal/native/lib/<goos>-<goarch>` in source checkouts, or from the checksum-verified release-asset cache. The explicit `datafusion_use_bundled` mode links the platform-specific static archive from `internal/native/lib/<goos>-<goarch>/libdatafusion_go.a`.

--- a/internal/tools/genversions/check_bump.go
+++ b/internal/tools/genversions/check_bump.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+)
+
+func checkVersionBump(baseRef string) error {
+	commit, err := gitOutput("rev-parse", "--verify", "--end-of-options", baseRef+"^{commit}")
+	if err != nil {
+		return err
+	}
+	baseCommit := strings.TrimSpace(string(commit))
+	data, err := gitOutput("show", baseCommit+":versions.toml")
+	if err != nil {
+		return err
+	}
+	base, err := parseConfig(baseCommit+":versions.toml", data)
+	if err != nil {
+		return err
+	}
+	current, err := readConfig("versions.toml")
+	if err != nil {
+		return err
+	}
+	// Include both sides of renames so moving a shipped file cannot bypass the check.
+	diff, err := gitOutput("diff", "--name-only", "--no-renames", "-z", baseCommit, "--")
+	if err != nil {
+		return err
+	}
+	var shipped []string
+	for _, name := range strings.Split(string(diff), "\x00") {
+		if isShippedFile(name) {
+			shipped = append(shipped, name)
+		}
+	}
+	if err := validateVersionBump(base, current, shipped); err != nil {
+		return err
+	}
+	if current.releaseTag() == base.releaseTag() {
+		fmt.Println("No shipped package changes require a release version bump.")
+		return nil
+	}
+	tags, err := gitOutput("tag", "--list", current.releaseTag())
+	if err != nil {
+		return err
+	}
+	if len(strings.TrimSpace(string(tags))) != 0 {
+		return fmt.Errorf("release tag %s already exists; choose the next unreleased version", current.releaseTag())
+	}
+	changelog, err := os.ReadFile("CHANGELOG.md")
+	if err != nil {
+		return err
+	}
+	if !hasReleaseNotes(string(changelog), current.releaseTag()) {
+		return fmt.Errorf("CHANGELOG.md needs a non-empty '## %s' or '## %s - <date>' entry", current.releaseTag(), current.releaseTag())
+	}
+	fmt.Printf("Release version %s -> %s and changelog entry verified.\n", base.releaseTag(), current.releaseTag())
+	return nil
+}
+
+func gitOutput(args ...string) ([]byte, error) {
+	output, err := exec.Command("git", args...).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, output)
+	}
+	return output, nil
+}
+
+func validateVersionBump(base, current config, shipped []string) error {
+	if current.ABIVersion < base.ABIVersion {
+		return fmt.Errorf("abi.version must not decrease (%d -> %d)", base.ABIVersion, current.ABIVersion)
+	}
+	if current.releaseTag() == base.releaseTag() {
+		if len(shipped) != 0 || current.ABIVersion != base.ABIVersion {
+			return fmt.Errorf("shipped package changes require a new release version (still %s); update versions.toml, run make generate, and add release notes in CHANGELOG.md; changed files: %v", current.releaseTag(), shipped)
+		}
+		return nil
+	}
+	if current.GoMajor != base.GoMajor && current.GoMajor != base.GoMajor+1 {
+		return fmt.Errorf("datafusion_go.major must stay at %d or increment to %d", base.GoMajor, base.GoMajor+1)
+	}
+	comparison := compareDataFusion(current, base)
+	if comparison < 0 {
+		return fmt.Errorf("datafusion.version must not decrease (%s -> %s)", base.DataFusionVersion, current.DataFusionVersion)
+	}
+	wantPatch := 0
+	if comparison == 0 {
+		wantPatch = base.GoPatch + 1
+	}
+	if current.GoPatch != wantPatch {
+		return fmt.Errorf("datafusion_go.patch must be %d for DataFusion %s (got %d): use 0 for a new DataFusion version, otherwise increment the previous patch", wantPatch, current.DataFusionVersion, current.GoPatch)
+	}
+	return nil
+}
+
+func compareDataFusion(a, b config) int {
+	for _, pair := range [][2]int{{a.DataFusionMajor, b.DataFusionMajor}, {a.DataFusionMinor, b.DataFusionMinor}, {a.DataFusionPatch, b.DataFusionPatch}} {
+		if comparison := cmp.Compare(pair[0], pair[1]); comparison != 0 {
+			return comparison
+		}
+	}
+	return 0
+}
+
+func isShippedFile(name string) bool {
+	switch name {
+	case "go.mod", "go.sum", "rust/Cargo.toml", "rust/Cargo.lock", "rust/build.rs",
+		"Makefile", ".gitattributes", ".github/workflows/release.yml":
+		return true
+	}
+	base := path.Base(name)
+	if strings.HasSuffix(base, "_test.go") || strings.HasSuffix(base, ".md") || strings.Contains(name, "/testdata/") {
+		return false
+	}
+	for _, prefix := range []string{"docs/", "examples/", "testdata/", "scripts/", ".agents/", ".codex/", ".github/", "internal/tools/", "internal/conformance/"} {
+		if strings.HasPrefix(name, prefix) {
+			return false
+		}
+	}
+	if !strings.Contains(name, "/") {
+		return strings.HasSuffix(name, ".go") || strings.HasSuffix(name, ".c") || strings.HasSuffix(name, ".h")
+	}
+	if strings.HasPrefix(name, "internal/") {
+		return !strings.HasPrefix(base, "test_") && !strings.HasPrefix(base, "sqllogictest.")
+	}
+	if strings.HasSuffix(name, ".go") {
+		return true
+	}
+	if strings.HasPrefix(name, "rust/src/") {
+		return base != "tests.rs" && !strings.HasSuffix(base, "_tests.rs") &&
+			!strings.Contains(name, "/tests/") && name != "rust/src/sqllogictest.rs" &&
+			!strings.HasPrefix(name, "rust/src/sqllogictest/") &&
+			name != "rust/src/abi/contract_generated.rs"
+	}
+	return strings.HasPrefix(name, "rust/include/")
+}
+
+func hasReleaseNotes(changelog, tag string) bool {
+	heading := "## " + tag
+	inRelease := false
+	for _, line := range strings.Split(changelog, "\n") {
+		if line == heading || strings.HasPrefix(line, heading+" - ") {
+			inRelease = true
+			continue
+		}
+		if inRelease && strings.HasPrefix(line, "## ") {
+			return false
+		}
+		if inRelease && strings.TrimSpace(line) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tools/genversions/check_bump_test.go
+++ b/internal/tools/genversions/check_bump_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestVersionBumpPolicy(t *testing.T) {
+	version := func(df string, major, patch, abi int) config {
+		t.Helper()
+		data := fmt.Sprintf("[datafusion]\nversion = %q\n[datafusion_go]\nmajor = %d\npatch = %d\n[abi]\nversion = %d\n", df, major, patch, abi)
+		cfg, err := parseConfig("test", []byte(data))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return cfg
+	}
+	base := version("55.0.0", 0, 1, 1)
+	for _, test := range []struct {
+		name    string
+		base    config
+		current config
+		shipped bool
+		wantErr string
+	}{
+		{"docs only", base, base, false, ""},
+		{"forgotten bump", base, base, true, "require a new release version"},
+		{"next patch", base, version("55.0.0", 0, 2, 1), true, ""},
+		{"release-only PR", base, version("55.0.0", 0, 2, 1), false, ""},
+		{"skipped patch", base, version("55.0.0", 0, 3, 1), true, "patch must be 2"},
+		{"patch rollback", base, version("55.0.0", 0, 0, 1), true, "patch must be 2"},
+		{"new engine major", base, version("56.0.0", 0, 0, 1), true, ""},
+		{"new engine minor", base, version("55.1.0", 0, 0, 1), true, ""},
+		{"new engine patch", base, version("55.0.1", 0, 0, 1), true, ""},
+		{"new engine without reset", base, version("56.0.0", 0, 2, 1), true, "patch must be 0"},
+		{"engine rollback", base, version("54.1.0", 0, 0, 1), true, "datafusion.version must not decrease"},
+		{"module major", base, version("55.0.0", 1, 2, 1), true, ""},
+		{"module major skips", base, version("55.0.0", 2, 2, 1), true, "major must stay"},
+		{"module major rollback", version("55.0.0", 1, 1, 1), version("55.0.0", 0, 2, 1), true, "major must stay"},
+		{"ABI without release", base, version("55.0.0", 0, 1, 2), false, "require a new release version"},
+		{"ABI rollback", base, version("55.0.0", 0, 2, 0), true, "abi.version must not decrease"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var files []string
+			if test.shipped {
+				files = []string{"connection.go"}
+			}
+			err := validateVersionBump(test.base, test.current, files)
+			assertBumpError(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestShippedFiles(t *testing.T) {
+	for _, name := range []string{
+		"connection.go", "version.go", "shim.c", "shim.h", "go.mod", "go.sum", "Makefile", ".gitattributes",
+		".github/workflows/release.yml", "internal/native/native.go", "internal/native/dynamic_loader.h",
+		"internal/native/lib/SHA256SUMS", "internal/newpackage/feature.go", "newpackage/api.go", "rust/Cargo.toml", "rust/Cargo.lock",
+		"rust/build.rs", "rust/include/datafusion_go.h", "rust/src/query.rs", "rust/src/query/new_module.rs",
+	} {
+		if !isShippedFile(name) {
+			t.Errorf("shipped file ignored: %s", name)
+		}
+	}
+	for _, name := range []string{
+		"", "versions.toml", "README.md", "CHANGELOG.md", "docs/testing.md", "examples/simple/main.go",
+		"connection_test.go", "sqllogictest_test.go", "testdata/new.slt", "internal/native/native_test.go",
+		"internal/native/test_coverage.go", "internal/native/sqllogictest.go", "internal/native/sqllogictest.h",
+		"internal/native/README.md",
+		"internal/native/testdata/fixture.c", "internal/conformance/corpus.go", "internal/tools/genversions/main.go",
+		"rust/src/query/tests.rs", "rust/src/query/tests/prepare.rs", "rust/src/coverage_tests.rs",
+		"rust/src/sqllogictest.rs", "rust/src/sqllogictest/coverage.rs", "rust/src/abi/contract_generated.rs",
+		"rust/tests/conformance.rs", "rust/fuzz/Cargo.toml", "scripts/sqllogictest.py", ".github/workflows/ci.yml",
+	} {
+		if isShippedFile(name) {
+			t.Errorf("development file requires a release: %s", name)
+		}
+	}
+}
+
+func TestReleaseNotesHeading(t *testing.T) {
+	for _, test := range []struct {
+		text string
+		want bool
+	}{
+		{"## v0.550000.2\n\n- Fixed a bug.\n", true},
+		{"## v0.550000.2 - 2026-09-09\n\nRelease notes.\n", true},
+		{"## v0.550000.2\n\n", false},
+		{"## v0.550000.2\n\n## v0.550000.1\nOld notes.\n", false},
+		{"## v0.550000.20\nOther release.\n", false},
+		{"## v0.550000.2-rc1\nPrerelease.\n", false},
+		{"## v0.550000.1\nMentions v0.550000.2.\n", false},
+	} {
+		if got := hasReleaseNotes(test.text, "v0.550000.2"); got != test.want {
+			t.Errorf("hasReleaseNotes(%q) = %t, want %t", test.text, got, test.want)
+		}
+	}
+}
+
+func TestVersionBumpAgainstGitBase(t *testing.T) {
+	t.Chdir(t.TempDir())
+	git := func(args ...string) string {
+		t.Helper()
+		output, err := gitOutput(args...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return strings.TrimSpace(string(output))
+	}
+	git("init", "-q")
+	writeFixture(t, "versions.toml", sampleConfig)
+	writeFixture(t, "CHANGELOG.md", "## v0.530102.3\n\nOld notes.\n")
+	writeFixture(t, "driver.go", "package driver\n")
+	writeFixture(t, "README.md", "Documentation.\n")
+	git("add", ".")
+	git("-c", "user.name=Version test", "-c", "user.email=version-test@example.invalid",
+		"-c", "commit.gpgsign=false", "-c", "core.hooksPath=.git/disabled-hooks", "commit", "-qm", "base")
+	base := git("rev-parse", "HEAD")
+	git("tag", "v0.530102.3")
+	writeFixture(t, "README.md", "Updated documentation.\n")
+	assertBumpError(t, checkVersionBump(base), "")
+
+	// A deletion or rename out of the package still requires a release.
+	git("mv", "driver.go", "example.txt")
+	assertBumpError(t, checkVersionBump(base), "require a new release version")
+	git("mv", "example.txt", "driver.go")
+	writeFixture(t, "driver.go", "package driver\n// Shipped change.\n")
+	assertBumpError(t, checkVersionBump(base), "require a new release version")
+
+	writeFixture(t, "versions.toml", strings.Replace(sampleConfig, "patch = 3", "patch = 4", 1))
+	assertBumpError(t, checkVersionBump(base), "CHANGELOG.md needs a non-empty")
+	writeFixture(t, "CHANGELOG.md", "## v0.530102.4\n\nNew release notes.\n")
+	assertBumpError(t, checkVersionBump(base), "")
+	git("tag", "v0.530102.4")
+	assertBumpError(t, checkVersionBump(base), "already exists")
+	assertBumpError(t, checkVersionBump("missing-base"), "git rev-parse")
+	if err := os.WriteFile("versions.toml", []byte("broken config"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	assertBumpError(t, checkVersionBump(base), "key outside section")
+}
+
+func assertBumpError(t *testing.T, err error, want string) {
+	t.Helper()
+	if want == "" {
+		if err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want %q", err, want)
+	}
+}

--- a/internal/tools/genversions/main.go
+++ b/internal/tools/genversions/main.go
@@ -25,7 +25,15 @@ type config struct {
 func main() {
 	check := flag.Bool("check", false, "check generated files without writing")
 	githubOutput := flag.String("github-output", "", "append computed release values to a GitHub Actions output file")
+	baseRef := flag.String("base-ref", "", "check release version changes against this Git commit or ref")
 	flag.Parse()
+
+	if *baseRef != "" {
+		if err := checkVersionBump(*baseRef); err != nil {
+			fatal(err)
+		}
+		return
+	}
 
 	if err := run(*check, *githubOutput); err != nil {
 		fatal(err)
@@ -88,7 +96,10 @@ func readConfig(path string) (config, error) {
 	if err != nil {
 		return config{}, err
 	}
+	return parseConfig(path, data)
+}
 
+func parseConfig(path string, data []byte) (config, error) {
 	values := map[string]string{}
 	sections := map[string]bool{}
 	section := ""


### PR DESCRIPTION
PR #28 changed shipped code while retaining an already-released version, so release automation had no new tag to publish. The existing changelog check accepted the old release's notes. This adds a version check to the existing Go CI job, alongside the generated-file and changelog checks.

- Compare pull requests with their base commit and pushes to main with the previous commit. Fetch complete history and tags so the check can detect reused release tags.
- Require a release bump for shipped Go/Rust code, native headers and libraries, dependency manifests, build configuration, and the release workflow. Documentation, examples, test-only modules, fixtures, and development tooling can retain the current version. File deletions and moves out of the shipped package also require a bump.
- Require the next patch for the same DataFusion version, or patch zero for a newer DataFusion version. Reject skipped or decreasing module majors, DataFusion/ABI rollbacks, existing release tags, and missing or empty release notes.
- Reuse the version parser and document the policy and local check command in CONTRIBUTING.md.

The separate release-only follow-up is #29, which adds v0.550000.2 and its changelog entry. This PR changes CI and development tooling only.

Validation passed:

- `make lint`, `make test`, `make test.source`, and `make rust.test`
- Workflow lint with actionlint
- Policy tests covering version transitions, shipped-file classification, changelog headings, and a temporary Git repository with renames and reused tags
- The check accepts this tooling-only PR and rejects the historical PR #28 changes when compared with their original base, with an explicit missing-version-bump error
